### PR TITLE
Adding Multithreading support

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,7 +5,7 @@
 
 # Need this for writing output files larger than 2GB on 32-bit Linux
 # (untested on other systems)
-CPPFLAGS := -D_FILE_OFFSET_BITS=64
+CPPFLAGS := -D_FILE_OFFSET_BITS=64 -g
 
 # Use -D to define LHTARGET, AD, SCANNING, NEUTRONS macros
 # for the C preprocesssor

--- a/UCGretina.cc
+++ b/UCGretina.cc
@@ -1,5 +1,9 @@
+#ifdef G4MULTITHREADED
 #include "G4MTRunManager.hh"
 #include "G4Threading.hh"
+#else
+#include "G4RunManager.hh"
+#endif
 #include "G4UImanager.hh"
 
 #include "G4UIterminal.hh"
@@ -31,8 +35,12 @@ int main(int argc,char** argv)
 {
   
   // Construct the default run manager
+#ifdef G4MULTITHREADED
   G4MTRunManager* runManager = new G4MTRunManager;
   runManager->SetNumberOfThreads(G4Threading::G4GetNumberOfCores());
+#else
+  G4RunManager* runManager = new G4RunManager;
+#endif
 
   G4cout << "Git commit: " << GIT_HASH << G4endl;
   G4cout << "Git branch: " << GIT_BRANCH << G4endl;

--- a/UCGretina.cc
+++ b/UCGretina.cc
@@ -1,4 +1,5 @@
-#include "G4RunManager.hh"
+#include "G4MTRunManager.hh"
+#include "G4Threading.hh"
 #include "G4UImanager.hh"
 
 #include "G4UIterminal.hh"
@@ -10,13 +11,7 @@
 
 #include "DetectorConstruction.hh"
 #include "PhysicsList.hh"
-#include "PrimaryGeneratorAction.hh"
-#include "PrimaryGeneratorAction_Messenger.hh"
-#include "TrackingAction.hh"
-#include "SteppingAction.hh"
-#include "EventAction.hh"
-#include "EventAction_Messenger.hh"
-#include "RunAction.hh"
+#include "ActionInitialization.hh"
 #include "Incoming_Beam.hh"
 #include "Incoming_Beam_Messenger.hh"
 #include "Outgoing_Beam.hh"
@@ -36,7 +31,8 @@ int main(int argc,char** argv)
 {
   
   // Construct the default run manager
-  G4RunManager* runManager = new G4RunManager;
+  G4MTRunManager* runManager = new G4MTRunManager;
+  runManager->SetNumberOfThreads(G4Threading::G4GetNumberOfCores());
 
   G4cout << "Git commit: " << GIT_HASH << G4endl;
   G4cout << "Git branch: " << GIT_BRANCH << G4endl;
@@ -60,23 +56,7 @@ int main(int argc,char** argv)
   physicsList->SetOutgoingBeam(BeamOut);
   Outgoing_Beam_Messenger* OutgoingBeamMessenger = new Outgoing_Beam_Messenger(BeamOut);
 
-  // set mandatory user action class
-  EventAction* eventAction = new EventAction();
-  EventAction_Messenger* eventActionMessenger = new EventAction_Messenger(eventAction);
-  runManager->SetUserAction(eventAction);
-
-  PrimaryGeneratorAction* generatorAction = new PrimaryGeneratorAction(detector,BeamIn,BeamOut);
-  PrimaryGeneratorAction_Messenger* generatorActionMessenger = new PrimaryGeneratorAction_Messenger(generatorAction);
-
-  runManager->SetUserAction(generatorAction);
-  RunAction* runAction = new RunAction(detector,BeamIn,eventAction);
-  runManager->SetUserAction(runAction);
-
-  TrackingAction* trackingAction = new TrackingAction(eventAction);
-  runManager->SetUserAction(trackingAction);
-
-  SteppingAction* steppingAction = new SteppingAction();
-  runManager->SetUserAction(steppingAction);
+  runManager->SetUserInitialization(new ActionInitialization(detector, BeamIn, BeamOut, /*enableStepping=*/true));
 
   G4UIsession* session=0;
 
@@ -142,10 +122,6 @@ int main(int argc,char** argv)
   delete BeamOut;
 
   delete OutgoingBeamMessenger;
-
-  delete eventActionMessenger;
-
-  delete generatorActionMessenger;
 
   return 0;
 }

--- a/UCGretina_LH.cc
+++ b/UCGretina_LH.cc
@@ -1,5 +1,9 @@
+#ifdef G4MULTITHREADED
 #include "G4MTRunManager.hh"
 #include "G4Threading.hh"
+#else
+#include "G4RunManager.hh"
+#endif
 #include "G4UImanager.hh"
 
 #include "G4UIterminal.hh"
@@ -31,8 +35,12 @@ int main(int argc,char** argv)
 {
   
   // Construct the default run manager
+#ifdef G4MULTITHREADED
   G4MTRunManager* runManager = new G4MTRunManager;
   runManager->SetNumberOfThreads(G4Threading::G4GetNumberOfCores());
+#else
+  G4RunManager* runManager = new G4RunManager;
+#endif
 
   G4cout << "Git commit: " << GIT_HASH << G4endl;
   G4cout << "Git branch: " << GIT_BRANCH << G4endl;

--- a/UCGretina_LH.cc
+++ b/UCGretina_LH.cc
@@ -1,4 +1,5 @@
-#include "G4RunManager.hh"
+#include "G4MTRunManager.hh"
+#include "G4Threading.hh"
 #include "G4UImanager.hh"
 
 #include "G4UIterminal.hh"
@@ -10,13 +11,7 @@
 
 #include "DetectorConstruction.hh"
 #include "PhysicsList.hh"
-#include "PrimaryGeneratorAction.hh"
-#include "PrimaryGeneratorAction_Messenger.hh"
-#include "TrackingAction.hh"
-#include "SteppingAction.hh"
-#include "EventAction.hh"
-#include "EventAction_Messenger.hh"
-#include "RunAction.hh"
+#include "ActionInitialization.hh"
 #include "Incoming_Beam.hh"
 #include "Incoming_Beam_Messenger.hh"
 #include "Outgoing_Beam.hh"
@@ -36,7 +31,8 @@ int main(int argc,char** argv)
 {
   
   // Construct the default run manager
-  G4RunManager* runManager = new G4RunManager;
+  G4MTRunManager* runManager = new G4MTRunManager;
+  runManager->SetNumberOfThreads(G4Threading::G4GetNumberOfCores());
 
   G4cout << "Git commit: " << GIT_HASH << G4endl;
   G4cout << "Git branch: " << GIT_BRANCH << G4endl;
@@ -60,23 +56,7 @@ int main(int argc,char** argv)
   physicsList->SetOutgoingBeam(BeamOut);
   Outgoing_Beam_Messenger* OutgoingBeamMessenger = new Outgoing_Beam_Messenger(BeamOut);
 
-  // set mandatory user action class
-  EventAction* eventAction = new EventAction();
-  EventAction_Messenger* eventActionMessenger = new EventAction_Messenger(eventAction);
-  runManager->SetUserAction(eventAction);
-
-  PrimaryGeneratorAction* generatorAction = new PrimaryGeneratorAction(detector,BeamIn,BeamOut);
-  PrimaryGeneratorAction_Messenger* generatorActionMessenger = new PrimaryGeneratorAction_Messenger(generatorAction);
-
-  runManager->SetUserAction(generatorAction);
-  RunAction* runAction = new RunAction(detector,BeamIn,eventAction);
-  runManager->SetUserAction(runAction);
-
-  TrackingAction* trackingAction = new TrackingAction(eventAction);
-  runManager->SetUserAction(trackingAction);
-
-  SteppingAction* steppingAction = new SteppingAction();
-  runManager->SetUserAction(steppingAction);
+  runManager->SetUserInitialization(new ActionInitialization(detector, BeamIn, BeamOut, /*enableStepping=*/true));
 
   G4UIsession* session=0;
 
@@ -142,10 +122,6 @@ int main(int argc,char** argv)
   delete BeamOut;
 
   delete OutgoingBeamMessenger;
-
-  delete eventActionMessenger;
-
-  delete generatorActionMessenger;
 
   return 0;
 }

--- a/UCGretina_LH_Pol.cc
+++ b/UCGretina_LH_Pol.cc
@@ -1,5 +1,9 @@
+#ifdef G4MULTITHREADED
 #include "G4MTRunManager.hh"
 #include "G4Threading.hh"
+#else
+#include "G4RunManager.hh"
+#endif
 #include "G4UImanager.hh"
 
 #include "G4UIterminal.hh"
@@ -31,8 +35,12 @@ int main(int argc,char** argv)
 {
   
   // Construct the default run manager
+#ifdef G4MULTITHREADED
   G4MTRunManager* runManager = new G4MTRunManager;
   runManager->SetNumberOfThreads(G4Threading::G4GetNumberOfCores());
+#else
+  G4RunManager* runManager = new G4RunManager;
+#endif
 
   G4cout << "Git commit: " << GIT_HASH << G4endl;
   G4cout << "Git branch: " << GIT_BRANCH << G4endl;

--- a/UCGretina_LH_Pol.cc
+++ b/UCGretina_LH_Pol.cc
@@ -1,4 +1,5 @@
-#include "G4RunManager.hh"
+#include "G4MTRunManager.hh"
+#include "G4Threading.hh"
 #include "G4UImanager.hh"
 
 #include "G4UIterminal.hh"
@@ -10,13 +11,7 @@
 
 #include "DetectorConstruction.hh"
 #include "PhysicsList.hh"
-#include "PrimaryGeneratorAction.hh"
-#include "PrimaryGeneratorAction_Messenger.hh"
-#include "TrackingAction.hh"
-#include "SteppingAction.hh"
-#include "EventAction.hh"
-#include "EventAction_Messenger.hh"
-#include "RunAction.hh"
+#include "ActionInitialization.hh"
 #include "Incoming_Beam.hh"
 #include "Incoming_Beam_Messenger.hh"
 #include "Outgoing_Beam.hh"
@@ -36,7 +31,8 @@ int main(int argc,char** argv)
 {
   
   // Construct the default run manager
-  G4RunManager* runManager = new G4RunManager;
+  G4MTRunManager* runManager = new G4MTRunManager;
+  runManager->SetNumberOfThreads(G4Threading::G4GetNumberOfCores());
 
   G4cout << "Git commit: " << GIT_HASH << G4endl;
   G4cout << "Git branch: " << GIT_BRANCH << G4endl;
@@ -60,23 +56,7 @@ int main(int argc,char** argv)
   physicsList->SetOutgoingBeam(BeamOut);
   Outgoing_Beam_Messenger* OutgoingBeamMessenger = new Outgoing_Beam_Messenger(BeamOut);
 
-  // set mandatory user action class
-  EventAction* eventAction = new EventAction();
-  EventAction_Messenger* eventActionMessenger = new EventAction_Messenger(eventAction);
-  runManager->SetUserAction(eventAction);
-
-  PrimaryGeneratorAction* generatorAction = new PrimaryGeneratorAction(detector,BeamIn,BeamOut);
-  PrimaryGeneratorAction_Messenger* generatorActionMessenger = new PrimaryGeneratorAction_Messenger(generatorAction);
-
-  runManager->SetUserAction(generatorAction);
-  RunAction* runAction = new RunAction(detector,BeamIn,eventAction);
-  runManager->SetUserAction(runAction);
-
-  TrackingAction* trackingAction = new TrackingAction(eventAction);
-  runManager->SetUserAction(trackingAction);
-
-  SteppingAction* steppingAction = new SteppingAction();
-  runManager->SetUserAction(steppingAction);
+  runManager->SetUserInitialization(new ActionInitialization(detector, BeamIn, BeamOut, /*enableStepping=*/true));
 
   G4UIsession* session=0;
 
@@ -142,10 +122,6 @@ int main(int argc,char** argv)
   delete BeamOut;
 
   delete OutgoingBeamMessenger;
-
-  delete eventActionMessenger;
-
-  delete generatorActionMessenger;
 
   return 0;
 }

--- a/UCGretina_Pol.cc
+++ b/UCGretina_Pol.cc
@@ -1,5 +1,9 @@
+#ifdef G4MULTITHREADED
 #include "G4MTRunManager.hh"
 #include "G4Threading.hh"
+#else
+#include "G4RunManager.hh"
+#endif
 #include "G4UImanager.hh"
 
 #include "G4UIterminal.hh"
@@ -31,8 +35,12 @@ int main(int argc,char** argv)
 {
   
   // Construct the default run manager
+#ifdef G4MULTITHREADED
   G4MTRunManager* runManager = new G4MTRunManager;
   runManager->SetNumberOfThreads(G4Threading::G4GetNumberOfCores());
+#else
+  G4RunManager* runManager = new G4RunManager;
+#endif
 
   G4cout << "Git commit: " << GIT_HASH << G4endl;
   G4cout << "Git branch: " << GIT_BRANCH << G4endl;

--- a/UCGretina_Pol.cc
+++ b/UCGretina_Pol.cc
@@ -1,4 +1,5 @@
-#include "G4RunManager.hh"
+#include "G4MTRunManager.hh"
+#include "G4Threading.hh"
 #include "G4UImanager.hh"
 
 #include "G4UIterminal.hh"
@@ -10,13 +11,7 @@
 
 #include "DetectorConstruction.hh"
 #include "PhysicsList.hh"
-#include "PrimaryGeneratorAction.hh"
-#include "PrimaryGeneratorAction_Messenger.hh"
-#include "TrackingAction.hh"
-#include "SteppingAction.hh"
-#include "EventAction.hh"
-#include "EventAction_Messenger.hh"
-#include "RunAction.hh"
+#include "ActionInitialization.hh"
 #include "Incoming_Beam.hh"
 #include "Incoming_Beam_Messenger.hh"
 #include "Outgoing_Beam.hh"
@@ -36,7 +31,8 @@ int main(int argc,char** argv)
 {
   
   // Construct the default run manager
-  G4RunManager* runManager = new G4RunManager;
+  G4MTRunManager* runManager = new G4MTRunManager;
+  runManager->SetNumberOfThreads(G4Threading::G4GetNumberOfCores());
 
   G4cout << "Git commit: " << GIT_HASH << G4endl;
   G4cout << "Git branch: " << GIT_BRANCH << G4endl;
@@ -60,23 +56,7 @@ int main(int argc,char** argv)
   physicsList->SetOutgoingBeam(BeamOut);
   Outgoing_Beam_Messenger* OutgoingBeamMessenger = new Outgoing_Beam_Messenger(BeamOut);
 
-  // set mandatory user action class
-  EventAction* eventAction = new EventAction();
-  EventAction_Messenger* eventActionMessenger = new EventAction_Messenger(eventAction);
-  runManager->SetUserAction(eventAction);
-
-  PrimaryGeneratorAction* generatorAction = new PrimaryGeneratorAction(detector,BeamIn,BeamOut);
-  PrimaryGeneratorAction_Messenger* generatorActionMessenger = new PrimaryGeneratorAction_Messenger(generatorAction);
-
-  runManager->SetUserAction(generatorAction);
-  RunAction* runAction = new RunAction(detector,BeamIn,eventAction);
-  runManager->SetUserAction(runAction);
-
-  TrackingAction* trackingAction = new TrackingAction(eventAction);
-  runManager->SetUserAction(trackingAction);
-
-  SteppingAction* steppingAction = new SteppingAction();
-  runManager->SetUserAction(steppingAction);
+  runManager->SetUserInitialization(new ActionInitialization(detector, BeamIn, BeamOut, /*enableStepping=*/true));
 
   G4UIsession* session=0;
 
@@ -142,10 +122,6 @@ int main(int argc,char** argv)
   delete BeamOut;
 
   delete OutgoingBeamMessenger;
-
-  delete eventActionMessenger;
-
-  delete generatorActionMessenger;
 
   return 0;
 }

--- a/UCGretina_Scan.cc
+++ b/UCGretina_Scan.cc
@@ -1,4 +1,5 @@
-#include "G4RunManager.hh"
+#include "G4MTRunManager.hh"
+#include "G4Threading.hh"
 #include "G4UImanager.hh"
 
 #include "G4UIterminal.hh"
@@ -10,13 +11,7 @@
 
 #include "DetectorConstruction.hh"
 #include "PhysicsList.hh"
-#include "PrimaryGeneratorAction.hh"
-#include "PrimaryGeneratorAction_Messenger.hh"
-#include "TrackingAction.hh"
-#include "SteppingAction.hh"
-#include "EventAction.hh"
-#include "EventAction_Messenger.hh"
-#include "RunAction.hh"
+#include "ActionInitialization.hh"
 #include "Incoming_Beam.hh"
 #include "Incoming_Beam_Messenger.hh"
 #include "Outgoing_Beam.hh"
@@ -36,7 +31,8 @@ int main(int argc,char** argv)
 {
   
   // Construct the default run manager
-  G4RunManager* runManager = new G4RunManager;
+  G4MTRunManager* runManager = new G4MTRunManager;
+  runManager->SetNumberOfThreads(G4Threading::G4GetNumberOfCores());
 
   G4cout << "Git commit: " << GIT_HASH << G4endl;
   G4cout << "Git branch: " << GIT_BRANCH << G4endl;
@@ -60,24 +56,7 @@ int main(int argc,char** argv)
   physicsList->SetOutgoingBeam(BeamOut);
   Outgoing_Beam_Messenger* OutgoingBeamMessenger = new Outgoing_Beam_Messenger(BeamOut);
 
-  // set mandatory user action class
-  EventAction* eventAction = new EventAction();
-  EventAction_Messenger* eventActionMessenger = new EventAction_Messenger(eventAction);
-  runManager->SetUserAction(eventAction);
-
-  PrimaryGeneratorAction* generatorAction = new PrimaryGeneratorAction(detector,BeamIn,BeamOut);
-  PrimaryGeneratorAction_Messenger* generatorActionMessenger = new PrimaryGeneratorAction_Messenger(generatorAction);
-
-  runManager->SetUserAction(generatorAction);
-  RunAction* runAction = new RunAction(detector,BeamIn,eventAction);
-  runManager->SetUserAction(runAction);
-
-  TrackingAction* trackingAction = new TrackingAction(eventAction);
-  runManager->SetUserAction(trackingAction);
-
-  //  User Stepping Action only needed for in-beam simulations.
-  //  SteppingAction* steppingAction = new SteppingAction();
-  //  runManager->SetUserAction(steppingAction);
+  runManager->SetUserInitialization(new ActionInitialization(detector, BeamIn, BeamOut, /*enableStepping=*/false));
 
   G4UIsession* session=0;
 
@@ -143,10 +122,6 @@ int main(int argc,char** argv)
   delete BeamOut;
 
   delete OutgoingBeamMessenger;
-
-  delete eventActionMessenger;
-
-  delete generatorActionMessenger;
 
   return 0;
 }

--- a/UCGretina_Scan.cc
+++ b/UCGretina_Scan.cc
@@ -1,5 +1,9 @@
+#ifdef G4MULTITHREADED
 #include "G4MTRunManager.hh"
 #include "G4Threading.hh"
+#else
+#include "G4RunManager.hh"
+#endif
 #include "G4UImanager.hh"
 
 #include "G4UIterminal.hh"
@@ -31,8 +35,12 @@ int main(int argc,char** argv)
 {
   
   // Construct the default run manager
+#ifdef G4MULTITHREADED
   G4MTRunManager* runManager = new G4MTRunManager;
   runManager->SetNumberOfThreads(G4Threading::G4GetNumberOfCores());
+#else
+  G4RunManager* runManager = new G4RunManager;
+#endif
 
   G4cout << "Git commit: " << GIT_HASH << G4endl;
   G4cout << "Git branch: " << GIT_BRANCH << G4endl;

--- a/UCGretina_Scan_Pol.cc
+++ b/UCGretina_Scan_Pol.cc
@@ -1,5 +1,9 @@
+#ifdef G4MULTITHREADED
 #include "G4MTRunManager.hh"
 #include "G4Threading.hh"
+#else
+#include "G4RunManager.hh"
+#endif
 #include "G4UImanager.hh"
 
 #include "G4UIterminal.hh"
@@ -31,8 +35,12 @@ int main(int argc,char** argv)
 {
   
   // Construct the default run manager
+#ifdef G4MULTITHREADED
   G4MTRunManager* runManager = new G4MTRunManager;
   runManager->SetNumberOfThreads(G4Threading::G4GetNumberOfCores());
+#else
+  G4RunManager* runManager = new G4RunManager;
+#endif
 
   G4cout << "Git commit: " << GIT_HASH << G4endl;
   G4cout << "Git branch: " << GIT_BRANCH << G4endl;

--- a/UCGretina_Scan_Pol.cc
+++ b/UCGretina_Scan_Pol.cc
@@ -1,4 +1,5 @@
-#include "G4RunManager.hh"
+#include "G4MTRunManager.hh"
+#include "G4Threading.hh"
 #include "G4UImanager.hh"
 
 #include "G4UIterminal.hh"
@@ -10,13 +11,7 @@
 
 #include "DetectorConstruction.hh"
 #include "PhysicsList.hh"
-#include "PrimaryGeneratorAction.hh"
-#include "PrimaryGeneratorAction_Messenger.hh"
-#include "TrackingAction.hh"
-#include "SteppingAction.hh"
-#include "EventAction.hh"
-#include "EventAction_Messenger.hh"
-#include "RunAction.hh"
+#include "ActionInitialization.hh"
 #include "Incoming_Beam.hh"
 #include "Incoming_Beam_Messenger.hh"
 #include "Outgoing_Beam.hh"
@@ -36,7 +31,8 @@ int main(int argc,char** argv)
 {
   
   // Construct the default run manager
-  G4RunManager* runManager = new G4RunManager;
+  G4MTRunManager* runManager = new G4MTRunManager;
+  runManager->SetNumberOfThreads(G4Threading::G4GetNumberOfCores());
 
   G4cout << "Git commit: " << GIT_HASH << G4endl;
   G4cout << "Git branch: " << GIT_BRANCH << G4endl;
@@ -60,23 +56,7 @@ int main(int argc,char** argv)
   physicsList->SetOutgoingBeam(BeamOut);
   Outgoing_Beam_Messenger* OutgoingBeamMessenger = new Outgoing_Beam_Messenger(BeamOut);
 
-  // set mandatory user action class
-  EventAction* eventAction = new EventAction();
-  EventAction_Messenger* eventActionMessenger = new EventAction_Messenger(eventAction);
-  runManager->SetUserAction(eventAction);
-
-  PrimaryGeneratorAction* generatorAction = new PrimaryGeneratorAction(detector,BeamIn,BeamOut);
-  PrimaryGeneratorAction_Messenger* generatorActionMessenger = new PrimaryGeneratorAction_Messenger(generatorAction);
-
-  runManager->SetUserAction(generatorAction);
-  RunAction* runAction = new RunAction(detector,BeamIn,eventAction);
-  runManager->SetUserAction(runAction);
-
-  TrackingAction* trackingAction = new TrackingAction(eventAction);
-  runManager->SetUserAction(trackingAction);
-
-  SteppingAction* steppingAction = new SteppingAction();
-  runManager->SetUserAction(steppingAction);
+  runManager->SetUserInitialization(new ActionInitialization(detector, BeamIn, BeamOut, /*enableStepping=*/true));
 
   G4UIsession* session=0;
 
@@ -142,10 +122,6 @@ int main(int argc,char** argv)
   delete BeamOut;
 
   delete OutgoingBeamMessenger;
-
-  delete eventActionMessenger;
-
-  delete generatorActionMessenger;
 
   return 0;
 }

--- a/include/ActionInitialization.hh
+++ b/include/ActionInitialization.hh
@@ -1,0 +1,29 @@
+#ifndef ActionInitialization_h
+#define ActionInitialization_h 1
+
+#include "G4VUserActionInitialization.hh"
+
+class DetectorConstruction;
+class Incoming_Beam;
+class Outgoing_Beam;
+
+// Creates master/worker user actions for Geant4 MT.
+class ActionInitialization : public G4VUserActionInitialization {
+public:
+  ActionInitialization(DetectorConstruction* detector,
+                       Incoming_Beam* beamIn,
+                       Outgoing_Beam* beamOut,
+                       bool enableStepping);
+  ~ActionInitialization() override = default;
+
+  void BuildForMaster() const override;
+  void Build() const override;
+
+private:
+  DetectorConstruction* fDetector;
+  Incoming_Beam* fBeamIn;
+  Outgoing_Beam* fBeamOut;
+  bool fEnableStepping;
+};
+
+#endif

--- a/include/DetectorConstruction.hh
+++ b/include/DetectorConstruction.hh
@@ -50,9 +50,15 @@ public:
   DetectorConstruction();
   ~DetectorConstruction();
 
+  void ConstructSDandField() override;
+  
   G4VPhysicalVolume* Construct();
   Gretina_Array* GetGretina(){ return the_Gretina_Array;}
-  TrackerGammaSD* GetGammaSD(){ return TrackerGamma;}
+
+  ////// Prep for ConstructSDandField()
+  //TrackerGammaSD* GetGammaSD(){ return TrackerGamma;}
+  ///////
+  
 #ifdef LHTARGET
   G4UnionSolid* GetTarget(){return aTarget->GetTarget();}	
 #else
@@ -143,10 +149,11 @@ private:
   Experimental_Hall_Messenger* ExperimentalHallMessenger;
   Target_Messenger*    TargetMessenger;
   Background_Sphere_Messenger* BackgroundSphereMessenger;
-  TrackerGammaSD* TrackerGamma;
-  TrackerGammaSD_Messenger* TrackerGammaSDMessenger;
-  TrackerIonSD* TrackerIon;
-  TrackerIonSD_Messenger* TrackerIonSDMessenger;
+
+  // TrackerGammaSD* TrackerGamma;
+  // TrackerGammaSD_Messenger* TrackerGammaSDMessenger;
+  // TrackerIonSD* TrackerIon;
+  // TrackerIonSD_Messenger* TrackerIonSDMessenger;
 
   Gretina_Array_Messenger*  the_Gretina_Array_Messenger;
 #ifndef LHTARGET

--- a/include/DetectorConstruction.hh
+++ b/include/DetectorConstruction.hh
@@ -100,6 +100,13 @@ public:
   
   void Placement();
 
+#ifdef SCANNING
+  // In MT, don't reach into PrimaryGeneratorAction from geometry construction.
+  // Workers can query these controller positions from their own generator action.
+  G4double GetScanningTableControllerX() const;
+  G4double GetScanningTableControllerY() const;
+#endif
+
 private:
   DetectorConstruction_Messenger *myMessenger;
 

--- a/include/EventAction.hh
+++ b/include/EventAction.hh
@@ -22,6 +22,9 @@
 #include <fstream>
 #include <string>
 #include <fcntl.h>
+#include <vector>
+
+#include "G4Threading.hh"
 
 class EventAction : public G4UserEventAction
 {
@@ -101,6 +104,14 @@ class EventAction : public G4UserEventAction
     void SetThreshDE(G4double de){threshDE = de;}
   
   private:
+    G4String threadSuffixedFileName(const G4String& baseName) const;
+
+    // Large writeDecomp scratch buffers live on the heap (per EventAction / per worker)
+    // to avoid overflowing the small per-thread stack on macOS.
+    std::vector<CRYS_IPS> fCrysIps;
+    std::vector<G4double> fCrysGts; // flattened [decomp*MAX_INTPTS + ip]
+    std::vector<G4int> fProcessed;
+
     G4int ionCollectionID;
     G4int gammaCollectionID;
     G4String outFileName;

--- a/include/EventAction.hh
+++ b/include/EventAction.hh
@@ -104,7 +104,7 @@ class EventAction : public G4UserEventAction
     void SetThreshDE(G4double de){threshDE = de;}
   
   private:
-    G4String threadSuffixedFileName(const G4String& baseName) const;
+    G4String threadSuffix(const G4String& baseName) const;
 
     // Large writeDecomp scratch buffers live on the heap (per EventAction / per worker)
     // to avoid overflowing the small per-thread stack on macOS.

--- a/include/Git_Hash.hh
+++ b/include/Git_Hash.hh
@@ -1,5 +1,5 @@
 #ifndef Git_Hash_h
 #define Git_Hash_h
-#define GIT_HASH "c0b4e68023e6828e1e93d93b28ca24d882a1c23b"
+#define GIT_HASH "fda11fdd5ede593f3413b58694592e02b3224121"
 #define GIT_BRANCH "MT"
 #endif

--- a/include/Git_Hash.hh
+++ b/include/Git_Hash.hh
@@ -1,5 +1,5 @@
 #ifndef Git_Hash_h
 #define Git_Hash_h
-#define GIT_HASH "20b727ebaf86bbfea5277781e4b8abb2d5d4813b"
+#define GIT_HASH "b6f2326cc0362f7421b6048bdbe56fb55fa07932"
 #define GIT_BRANCH "MT"
 #endif

--- a/include/Git_Hash.hh
+++ b/include/Git_Hash.hh
@@ -1,5 +1,5 @@
 #ifndef Git_Hash_h
 #define Git_Hash_h
-#define GIT_HASH "53d6ce710a9981cc5a4b3dbfaf815bfbfb1a03b2"
+#define GIT_HASH "2598ba0fa5aeb4c94c503aa30e014a0588650778"
 #define GIT_BRANCH "MT"
 #endif

--- a/include/Git_Hash.hh
+++ b/include/Git_Hash.hh
@@ -1,5 +1,5 @@
 #ifndef Git_Hash_h
 #define Git_Hash_h
-#define GIT_HASH "09cea3a271fefc9cd708c8df0570a4674067b33a"
+#define GIT_HASH "997c64e4835a980aaf60edc2482117a47f3dcd1b"
 #define GIT_BRANCH "MT"
 #endif

--- a/include/Git_Hash.hh
+++ b/include/Git_Hash.hh
@@ -1,5 +1,5 @@
 #ifndef Git_Hash_h
 #define Git_Hash_h
-#define GIT_HASH "6a593c619db60a432e13e3f666f8064119ef76f9"
+#define GIT_HASH "09cea3a271fefc9cd708c8df0570a4674067b33a"
 #define GIT_BRANCH "MT"
 #endif

--- a/include/Git_Hash.hh
+++ b/include/Git_Hash.hh
@@ -1,5 +1,5 @@
 #ifndef Git_Hash_h
 #define Git_Hash_h
-#define GIT_HASH "997c64e4835a980aaf60edc2482117a47f3dcd1b"
+#define GIT_HASH "20b727ebaf86bbfea5277781e4b8abb2d5d4813b"
 #define GIT_BRANCH "MT"
 #endif

--- a/include/Git_Hash.hh
+++ b/include/Git_Hash.hh
@@ -1,5 +1,5 @@
 #ifndef Git_Hash_h
 #define Git_Hash_h
-#define GIT_HASH "2598ba0fa5aeb4c94c503aa30e014a0588650778"
+#define GIT_HASH "6a593c619db60a432e13e3f666f8064119ef76f9"
 #define GIT_BRANCH "MT"
 #endif

--- a/include/Git_Hash.hh
+++ b/include/Git_Hash.hh
@@ -1,5 +1,5 @@
 #ifndef Git_Hash_h
 #define Git_Hash_h
-#define GIT_HASH "b6f2326cc0362f7421b6048bdbe56fb55fa07932"
+#define GIT_HASH "c0b4e68023e6828e1e93d93b28ca24d882a1c23b"
 #define GIT_BRANCH "MT"
 #endif

--- a/include/Git_Hash.hh
+++ b/include/Git_Hash.hh
@@ -1,5 +1,5 @@
 #ifndef Git_Hash_h
 #define Git_Hash_h
-#define GIT_HASH "7ee1d909344da2dfb1dd6e312657833f2e08953b"
-#define GIT_BRANCH "geant4.10"
+#define GIT_HASH "53d6ce710a9981cc5a4b3dbfaf815bfbfb1a03b2"
+#define GIT_BRANCH "MT"
 #endif

--- a/include/Git_Hash.hh
+++ b/include/Git_Hash.hh
@@ -1,5 +1,5 @@
 #ifndef Git_Hash_h
 #define Git_Hash_h
-#define GIT_HASH "fda11fdd5ede593f3413b58694592e02b3224121"
+#define GIT_HASH "c42053c06fcc99868fa415765a279fcc274d28bc"
 #define GIT_BRANCH "MT"
 #endif

--- a/include/Gretina_Array.hh
+++ b/include/Gretina_Array.hh
@@ -174,7 +174,8 @@ class Gretina_Array
   //////////////////////////////////////////
   public:
     void SetCryostats(G4bool stat){cryostatStatus = stat;};
-
+    
+  
   private:
     G4ThreeVector               cryostatPos0;
     G4ThreeVector               cryostatPos;
@@ -332,6 +333,9 @@ public:
   //////////////// inline "get" methods
   ///////////////////////////////////////////
   public:
+    inline std::vector<CpolyhPoints>   GetPgons     () { return pgons;}; 
+  
+  public:
     inline G4double              GetThetaShift      () { return thetaShift;  };
     inline G4double              GetPhiShift        () { return phiShift;    };
     
@@ -344,6 +348,7 @@ public:
   public:
     inline G4bool                GetDrawReadOut     () { return drawReadOut; };
     inline G4bool                GetReadOut         () { return readOut; };
+    inline G4bool                GetMakeCapsule     () { return makeCapsule; };
 };
 
 #include "G4UImessenger.hh"

--- a/include/Outgoing_Beam.hh
+++ b/include/Outgoing_Beam.hh
@@ -22,6 +22,8 @@ using namespace std;
 
 #include "G4IonTable.hh"
 
+#include "G4Threading.hh"
+
 #include "Randomize.hh"
 #include "Incoming_Beam.hh"
 
@@ -71,15 +73,18 @@ public:
   G4int    AboveThreshold(){return ThresholdFlag;}
 
 private:
-  G4int Ain;
-  G4int Zin;
-  G4ThreeVector dirIn;
-  G4ThreeVector posIn;
-  G4ThreeVector posOut;
-  G4ThreeVector pIn;
-  G4int  ReactionFlag;
-  G4int  ThresholdFlag;
-  G4double      KEIn;
+  // Per-thread transient reaction state.
+  // These were previously shared members and caused cross-thread interference
+  // (e.g. ReactionFlag set in one thread affecting other threads).
+  static G4ThreadLocal G4int Ain;
+  static G4ThreadLocal G4int Zin;
+  static G4ThreadLocal G4ThreeVector dirIn;
+  static G4ThreadLocal G4ThreeVector posIn;
+  static G4ThreadLocal G4ThreeVector posOut;
+  static G4ThreadLocal G4ThreeVector pIn;
+  static G4ThreadLocal G4int ReactionFlag;
+  static G4ThreadLocal G4int ThresholdFlag;
+  static G4ThreadLocal G4double KEIn;
 
   std::vector<G4int> DZ;
   std::vector<G4int> DA;
@@ -89,9 +94,9 @@ private:
   G4double m2;
   G4double m3;
   G4double m4;
-  G4double ET;
-  G4double p1;
-  G4double sin2theta3_max;
+  static G4ThreadLocal G4double ET;
+  static G4ThreadLocal G4double p1;
+  static G4ThreadLocal G4double sin2theta3_max;
 
   G4double Ex,TarEx;
   std::vector<G4String> lvlDataFileNames;

--- a/include/PrimaryVertexInformation.hh
+++ b/include/PrimaryVertexInformation.hh
@@ -30,6 +30,7 @@ public:
   void SetExitTime(G4double t){ fExitTime = t; }
   void SetFilterCode(G4int c){ffiltercode = c;}
   void SetWriteEvent(G4bool b){fwrite = b;}
+  void SetReactionDepthZ(G4double z){ fReactionDepthZ = z; fHasReactionDepthZ = true; }
 
   G4double GetEmittedGammaEnergy(G4int i){ return fEmittedGammaEnergies[i]; }
   G4double GetEmittedGammaPosX(G4int i){ return fEmittedGammaPosX[i]; }
@@ -53,6 +54,8 @@ public:
   G4double GetExitTime(){ return fExitTime; }
   G4int    GetFilterCode(){return ffiltercode;}
   G4bool   WriteEvent(){return fwrite;}
+  G4bool   HasReactionDepthZ(){return fHasReactionDepthZ;}
+  G4double GetReactionDepthZ(){return fReactionDepthZ;}
 
 private:
 
@@ -79,6 +82,8 @@ private:
   G4double fExitTime;
   G4int    ffiltercode;
   G4bool   fwrite;
+  G4bool   fHasReactionDepthZ;
+  G4double fReactionDepthZ;
 };
 
 #endif

--- a/include/ScanningTable.hh
+++ b/include/ScanningTable.hh
@@ -47,13 +47,13 @@ class ScanningTable
   void SetControllerX(G4double value) { controllerX = value; }
   void SetControllerY(G4double value) { controllerY = value; }
   void SetControllerZ(G4double value) { controllerZ = value; }
-  G4double GetControllerX() { return controllerX; }
-  G4double GetControllerY() { return controllerY; }
-  G4double GetControllerZ() { return controllerZ; }
+  G4double GetControllerX() const { return controllerX; }
+  G4double GetControllerY() const { return controllerY; }
+  G4double GetControllerZ() const { return controllerZ; }
   void SetCollR(G4double value)  { collimatorRadius = value; }
   void SetSlitWidth(G4double value)  { slitWidth = value; }
   void SetCloverZ(G4double value){ cloverZ = value; }
-  G4double GetCloverZ() { return cloverZ + cloverOffset; }
+  G4double GetCloverZ() const { return cloverZ + cloverOffset; }
   void Report();
   
 private:

--- a/include/Target.hh
+++ b/include/Target.hh
@@ -45,10 +45,12 @@ class Target
   G4VPhysicalVolume* GetTargetPlacement(){return Target_phys;}
   void setTargetReactionDepth(G4double);
   void setPosition(G4double, G4double, G4double);
-  G4double GetTargetThickness(){return Target_thickness;}
-  G4ThreeVector* GetPos(){return Pos;}
+   G4double GetTargetThickness(){return Target_thickness;}
+   G4ThreeVector* GetPos(){return Pos;}
 
-private:
+ private:
+  void BuildSourceFrame();
+
   // dimensions
   G4double Target_side_x;
   G4double Target_side_y;
@@ -152,4 +154,3 @@ private:
 };
 
 #endif
-

--- a/include/Target_LH.hh
+++ b/include/Target_LH.hh
@@ -71,7 +71,9 @@ class Target
   G4double GetTargetCellDz(){return TargetDz;}
   G4ThreeVector* GetPos(){return Pos;}
 
-private:
+ private:
+  void BuildSourceFrame();
+
   G4String targetCellType;
 
   bool buildSled;
@@ -219,4 +221,3 @@ private:
 };
 
 #endif
-

--- a/include/TrackerGammaHit.hh
+++ b/include/TrackerGammaHit.hh
@@ -5,6 +5,7 @@
 #include "G4VHit.hh"
 #include "G4THitsCollection.hh"
 #include "G4Allocator.hh"
+#include "G4Threading.hh"
 #include "G4ThreeVector.hh"
 #include "G4SystemOfUnits.hh"
 #include <iomanip>
@@ -84,22 +85,23 @@ class TrackerGammaHit : public G4VHit
 
 typedef G4THitsCollection<TrackerGammaHit> TrackerGammaHitsCollection;
 
-extern G4Allocator<TrackerGammaHit> TrackerGammaHitAllocator;
+extern G4ThreadLocal G4Allocator<TrackerGammaHit>* TrackerGammaHitAllocator;
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 inline void* TrackerGammaHit::operator new(size_t)
 {
-  void *aHit;
-  aHit = (void *) TrackerGammaHitAllocator.MallocSingle();
-  return aHit;
+  if (!TrackerGammaHitAllocator) {
+    TrackerGammaHitAllocator = new G4Allocator<TrackerGammaHit>;
+  }
+  return (void*)TrackerGammaHitAllocator->MallocSingle();
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 inline void TrackerGammaHit::operator delete(void *aHit)
 {
-  TrackerGammaHitAllocator.FreeSingle((TrackerGammaHit*) aHit);
+  TrackerGammaHitAllocator->FreeSingle((TrackerGammaHit*)aHit);
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/include/TrackerGammaSD.hh
+++ b/include/TrackerGammaSD.hh
@@ -43,8 +43,9 @@ class TrackerGammaSD : public G4VSensitiveDetector
       G4double      phdA;
       G4double      phdB;
       G4double      posRes;
+      // Per-detector-instance hit collection id (avoids shared static across threads).
+      G4int         fHCID;
 };
 
 
 #endif
-

--- a/include/TrackerIonHit.hh
+++ b/include/TrackerIonHit.hh
@@ -12,6 +12,7 @@
 #include "G4VHit.hh"
 #include "G4THitsCollection.hh"
 #include "G4Allocator.hh"
+#include "G4Threading.hh"
 #include "G4ThreeVector.hh"
 #include "G4UnitsTable.hh"
 #include "G4SystemOfUnits.hh"
@@ -97,22 +98,23 @@ class TrackerIonHit : public G4VHit
 
 typedef G4THitsCollection<TrackerIonHit> TrackerIonHitsCollection;
 
-extern G4Allocator<TrackerIonHit> TrackerIonHitAllocator;
+extern G4ThreadLocal G4Allocator<TrackerIonHit>* TrackerIonHitAllocator;
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 inline void* TrackerIonHit::operator new(size_t)
 {
-  void *aHit;
-  aHit = (void *) TrackerIonHitAllocator.MallocSingle();
-  return aHit;
+  if (!TrackerIonHitAllocator) {
+    TrackerIonHitAllocator = new G4Allocator<TrackerIonHit>;
+  }
+  return (void*)TrackerIonHitAllocator->MallocSingle();
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 inline void TrackerIonHit::operator delete(void *aHit)
 {
-  TrackerIonHitAllocator.FreeSingle((TrackerIonHit*) aHit);
+  TrackerIonHitAllocator->FreeSingle((TrackerIonHit*)aHit);
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/include/TrackerIonSD.hh
+++ b/include/TrackerIonSD.hh
@@ -37,8 +37,10 @@ class TrackerIonSD : public G4VSensitiveDetector
   private:
       TrackerIonHitsCollection* ionCollection;
       G4bool print;
-    
-    
+      // Per-detector-instance hit collection id (avoids shared static across threads).
+      G4int fHCID;
+     
+     
 };
 
 

--- a/include/TrackerIonSD.hh
+++ b/include/TrackerIonSD.hh
@@ -38,6 +38,7 @@ class TrackerIonSD : public G4VSensitiveDetector
       TrackerIonHitsCollection* ionCollection;
       G4bool print;
     
+    
 };
 
 

--- a/src/ActionInitialization.cc
+++ b/src/ActionInitialization.cc
@@ -1,0 +1,41 @@
+#include "ActionInitialization.hh"
+
+#include "DetectorConstruction.hh"
+#include "Incoming_Beam.hh"
+#include "Outgoing_Beam.hh"
+
+#include "EventAction.hh"
+#include "EventAction_Messenger.hh"
+#include "PrimaryGeneratorAction.hh"
+#include "PrimaryGeneratorAction_Messenger.hh"
+#include "RunAction.hh"
+#include "TrackingAction.hh"
+#include "SteppingAction.hh"
+
+ActionInitialization::ActionInitialization(DetectorConstruction* detector,
+                                           Incoming_Beam* beamIn,
+                                           Outgoing_Beam* beamOut,
+                                           bool enableStepping)
+  : fDetector(detector), fBeamIn(beamIn), fBeamOut(beamOut), fEnableStepping(enableStepping) {}
+
+void ActionInitialization::BuildForMaster() const {
+  // Master does not process events; keep it minimal.
+  auto* eventAction = new EventAction();
+  SetUserAction(new RunAction(fDetector, fBeamIn, eventAction));
+}
+
+void ActionInitialization::Build() const {
+  auto* eventAction = new EventAction();
+  SetUserAction(eventAction);
+  (void)new EventAction_Messenger(eventAction);
+
+  auto* generatorAction = new PrimaryGeneratorAction(fDetector, fBeamIn, fBeamOut);
+  SetUserAction(generatorAction);
+  (void)new PrimaryGeneratorAction_Messenger(generatorAction);
+
+  SetUserAction(new RunAction(fDetector, fBeamIn, eventAction));
+  SetUserAction(new TrackingAction(eventAction));
+  if (fEnableStepping) {
+    SetUserAction(new SteppingAction());
+  }
+}

--- a/src/ActionInitialization.cc
+++ b/src/ActionInitialization.cc
@@ -20,6 +20,7 @@ ActionInitialization::ActionInitialization(DetectorConstruction* detector,
 
 void ActionInitialization::BuildForMaster() const {
   // Master does not process events; keep it minimal.
+  G4cout << "Building Master" << G4endl;
   auto* eventAction = new EventAction();
   SetUserAction(new RunAction(fDetector, fBeamIn, eventAction));
 }

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -166,19 +166,12 @@ void DetectorConstruction::Placement()
     leftClover->setY(scanningTable->GetCloverZ());
     leftClover->Construct();
   }
-  if( cloverStatus == "right" || cloverStatus == "both" ){
-    G4cout << "Constructing right clover detector." << G4endl;
-    rightClover = new Clover_Detector(ExpHall_log, "right");
-    rightClover->setY(scanningTable->GetCloverZ());
-    rightClover->Construct();
-  }
-  
-  // Position the source horizontally using scanning-table controller position
-  G4RunManager* runManager = G4RunManager::GetRunManager();
-  PrimaryGeneratorAction* generatorAction
-    = (PrimaryGeneratorAction*)runManager->GetUserPrimaryGeneratorAction();
-  generatorAction->SetSourceX(-scanningTable->GetControllerX());
-  generatorAction->SetSourceZ( scanningTable->GetControllerY());
+   if( cloverStatus == "right" || cloverStatus == "both" ){
+     G4cout << "Constructing right clover detector." << G4endl;
+     rightClover = new Clover_Detector(ExpHall_log, "right");
+     rightClover->setY(scanningTable->GetCloverZ());
+     rightClover->Construct();
+   }
 #endif
 #endif
 
@@ -222,6 +215,16 @@ void DetectorConstruction::Placement()
     the_Gretina_Array->Placement();
   }
 }
+
+#ifdef SCANNING
+G4double DetectorConstruction::GetScanningTableControllerX() const {
+  return scanningTable->GetControllerX();
+}
+
+G4double DetectorConstruction::GetScanningTableControllerY() const {
+  return scanningTable->GetControllerY();
+}
+#endif
 
 void DetectorConstruction::ConstructSDandField(){
   

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -33,12 +33,14 @@ DetectorConstruction::DetectorConstruction()
 
   materials = new Materials();
 
-  TrackerIon = new TrackerIonSD("IonTracker");
-  TrackerIonSDMessenger = new TrackerIonSD_Messenger(TrackerIon);
+  ////////// Prepping for ConstructSDandField()
+  // TrackerIon = new TrackerIonSD("IonTracker");
+  // TrackerIonSDMessenger = new TrackerIonSD_Messenger(TrackerIon);
 
-  TrackerGamma = new TrackerGammaSD("GammaTracker");
-  TrackerGammaSDMessenger = new TrackerGammaSD_Messenger(TrackerGamma);
-
+  // TrackerGamma = new TrackerGammaSD("GammaTracker");
+  // TrackerGammaSDMessenger = new TrackerGammaSD_Messenger(TrackerGamma);
+  //////////////
+  
   ExperimentalHall = new Experimental_Hall();
   ExperimentalHallMessenger = new Experimental_Hall_Messenger(ExperimentalHall);
   
@@ -90,8 +92,12 @@ DetectorConstruction::~DetectorConstruction()
 {
   delete ExperimentalHallMessenger;
   delete TargetMessenger;
-  delete TrackerIonSDMessenger;
-  delete TrackerGammaSDMessenger;
+
+  ///// Prepping for ConstructSDandField()
+  // delete TrackerIonSDMessenger;
+  // delete TrackerGammaSDMessenger;
+  /////
+  
 #ifndef LHTARGET
 #ifndef SCANNING
   delete BeamTubeMessenger;
@@ -105,15 +111,17 @@ DetectorConstruction::~DetectorConstruction()
 G4VPhysicalVolume* DetectorConstruction::Construct()
 {
 
+  ////////// Prep for ConstructSDandField()
   // Tracker for ions in the target
 
-  G4SDManager* SDman = G4SDManager::GetSDMpointer();
-  SDman->AddNewDetector( TrackerIon );
+  // G4SDManager* SDman = G4SDManager::GetSDMpointer();
+  // SDman->AddNewDetector( TrackerIon );
 
   // Tracker for gammas in GRETINA
 
-  SDman->AddNewDetector( TrackerGamma );
-
+  //SDman->AddNewDetector( TrackerGamma );
+  /////////
+  
   // Experimental Hall
 
   ExpHall_phys = ExperimentalHall->Construct();
@@ -157,14 +165,12 @@ void DetectorConstruction::Placement()
     leftClover = new Clover_Detector(ExpHall_log, "left");
     leftClover->setY(scanningTable->GetCloverZ());
     leftClover->Construct();
-    leftClover->MakeSensitive(TrackerGamma);
   }
   if( cloverStatus == "right" || cloverStatus == "both" ){
     G4cout << "Constructing right clover detector." << G4endl;
     rightClover = new Clover_Detector(ExpHall_log, "right");
     rightClover->setY(scanningTable->GetCloverZ());
     rightClover->Construct();
-    rightClover->MakeSensitive(TrackerGamma);
   }
   
   // Position the source horizontally using scanning-table controller position
@@ -179,7 +185,6 @@ void DetectorConstruction::Placement()
   // Target
   if( targetStatus ){
     aTarget->Construct(ExpHall_log);
-    aTarget->GetTargetLog()->SetSensitiveDetector(TrackerIon);
   }
 
 #ifndef SCANNING
@@ -206,7 +211,6 @@ void DetectorConstruction::Placement()
   }
   if( laBrStatus ){
     the_LaBr->Construct(ExpHall_log);
-    the_LaBr->MakeSensitive(TrackerGamma);
   }
 #endif
 
@@ -217,6 +221,55 @@ void DetectorConstruction::Placement()
 #endif
     the_Gretina_Array->Placement();
   }
+}
+
+void DetectorConstruction::ConstructSDandField(){
+  
+  auto *sdMan = G4SDManager::GetSDMpointer();
+  auto *TrackerIon = new TrackerIonSD("IonTracker");
+  auto *TrackerIonSDMessenger = new TrackerIonSD_Messenger(TrackerIon);
+
+  auto *TrackerGamma = new TrackerGammaSD("GammaTracker");
+  auto *TrackerGammaSDMessenger = new TrackerGammaSD_Messenger(TrackerGamma);
+
+  G4int depth;
+  auto makeCapsule = the_Gretina_Array->GetMakeCapsule();
+
+  if(makeCapsule)
+    depth = 2;
+  else
+    depth = 1;
+
+  TrackerGamma->SetDepth(depth);
+
+  for(auto pPg: the_Gretina_Array->GetPgons() ){
+    pPg.pDetL->SetSensitiveDetector(TrackerGamma);
+  }
+  
+  if( targetStatus ){
+    aTarget->GetTargetLog()->SetSensitiveDetector(TrackerIon);
+  }
+
+
+#ifndef LHTARGET
+  #ifndef SCANNING
+  #else
+  if( cloverStatus == "left"  || cloverStatus == "both" ){
+    leftClover->MakeSensitive(TrackerGamma);
+  }
+  if( cloverStatus == "right" || cloverStatus == "both" ){
+    rightClover->MakeSensitive(TrackerGamma);
+  }
+  #endif
+#endif
+  
+
+#ifndef SCANNING
+  if( laBrStatus){
+    the_LaBr->MakeSensitive(TrackerGamma);
+  }
+#endif
+  
 }
 
 ///////////////////

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -226,12 +226,16 @@ void DetectorConstruction::Placement()
 void DetectorConstruction::ConstructSDandField(){
   
   auto *sdMan = G4SDManager::GetSDMpointer();
+
   auto *TrackerIon = new TrackerIonSD("IonTracker");
   auto *TrackerIonSDMessenger = new TrackerIonSD_Messenger(TrackerIon);
-
+  sdMan->AddNewDetector(TrackerIon);
+  
   auto *TrackerGamma = new TrackerGammaSD("GammaTracker");
   auto *TrackerGammaSDMessenger = new TrackerGammaSD_Messenger(TrackerGamma);
-
+  sdMan->AddNewDetector(TrackerGamma);
+  
+  
   G4int depth;
   auto makeCapsule = the_Gretina_Array->GetMakeCapsule();
 

--- a/src/EventAction.cc
+++ b/src/EventAction.cc
@@ -65,6 +65,10 @@ G4String EventAction::threadSuffix(const G4String& baseName) const {
 
   // Geant4 MT worker id (typically 0..N-1). We use -1 for master.
   const auto tid = G4Threading::G4GetThreadId();
+  
+  if(tid<0) //For non-MT builds
+    return baseName;
+  
   const G4String suffix = "_t" + std::to_string(tid);
 
   // Insert suffix before the last '.' in the basename.

--- a/src/EventAction.cc
+++ b/src/EventAction.cc
@@ -53,13 +53,6 @@ void EventAction::BeginOfEventAction(const G4Event* ev)
   PrimaryVertexInformation* primaryVertexInfo
     = (PrimaryVertexInformation*)evt->GetPrimaryVertex()->GetUserInformation();
 
-  G4SDManager * SDman = G4SDManager::GetSDMpointer();
-
-  if(gammaCollectionID<0||ionCollectionID<0)
-    {
-      gammaCollectionID=SDman->GetCollectionID("gammaCollection");
-      ionCollectionID=SDman->GetCollectionID("ionCollection");
-    }
 
   // For event filter
   primaryVertexInfo->SetWriteEvent(false);
@@ -170,6 +163,13 @@ void EventAction::EndOfEventAction(const G4Event* ev)
   // Analyze hits and write event information to the output file.
   G4HCofThisEvent * HCE = evt->GetHCofThisEvent();
   if(HCE) {
+
+    G4SDManager * SDman = G4SDManager::GetSDMpointer();
+
+    if(gammaCollectionID<0)
+      gammaCollectionID=SDman->GetCollectionID("gammaCollection");
+    
+
 
     TrackerGammaHitsCollection* gammaCollection 
       = (TrackerGammaHitsCollection*)(HCE->GetHC(gammaCollectionID));
@@ -594,6 +594,15 @@ void EventAction::EndOfEventAction(const G4Event* ev)
   writeSim(timestamp, primaryVertexInfo);
 
   if(cacheOut){
+    
+    G4SDManager * SDman = G4SDManager::GetSDMpointer();
+
+    if(ionCollectionID<0)
+      ionCollectionID=SDman->GetCollectionID("ionCollection");
+
+    if(!ionCollectionID)
+      G4cout << "Couldn't find ionCollection" << G4endl;
+    
     TrackerIonHitsCollection* ionCollection 
       = (TrackerIonHitsCollection*)(HCE->GetHC(ionCollectionID));
     writeCache(ionCollection);

--- a/src/EventAction.cc
+++ b/src/EventAction.cc
@@ -640,12 +640,15 @@ void EventAction::EndOfEventAction(const G4Event* ev)
     if(ionCollectionID<0)
       ionCollectionID=SDman->GetCollectionID("ionCollection");
 
-    if(!ionCollectionID)
+    // Geant4 collection IDs are 0-based; ID==0 is valid. "Not found" is < 0.
+    if(ionCollectionID < 0){
       G4cout << "Couldn't find ionCollection" << G4endl;
-    
-    TrackerIonHitsCollection* ionCollection 
-      = (TrackerIonHitsCollection*)(HCE->GetHC(ionCollectionID));
-    writeCache(ionCollection);
+    } else if(HCE){
+      TrackerIonHitsCollection* ionCollection
+        = (TrackerIonHitsCollection*)(HCE->GetHC(ionCollectionID));
+      if(ionCollection)
+        writeCache(ionCollection);
+    }
   }
 
 }

--- a/src/EventAction.cc
+++ b/src/EventAction.cc
@@ -1183,7 +1183,7 @@ void EventAction::closeCacheOutputFile()
 //----------------------------------------------------
 void EventAction::openCacheInputFile(G4String FileName)
 {
-  cacheInputFileName = FileName;
+  cacheInputFileName = threadSuffix(FileName);
 #ifdef CACHETEXT
   if (!cacheInputFile.is_open())
     cacheInputFile.open(cacheInputFileName.c_str());

--- a/src/EventAction.cc
+++ b/src/EventAction.cc
@@ -6,6 +6,12 @@
 #include "G4Timer.hh"
 extern G4Timer Timerintern;
 
+#include "G4AutoLock.hh"
+
+namespace{
+  G4Mutex outputMutex = G4MUTEX_INITIALIZER;
+}
+
 EventAction::EventAction()
 { 
   ionCollectionID=-1;
@@ -54,7 +60,7 @@ EventAction::~EventAction()
   ;
 }
 
-G4String EventAction::threadSuffixedFileName(const G4String& baseName) const {
+G4String EventAction::threadSuffix(const G4String& baseName) const {
   if (baseName.empty()) return baseName;
 
   // Geant4 MT worker id (typically 0..N-1). We use -1 for master.
@@ -103,6 +109,8 @@ void EventAction::EndOfEventAction(const G4Event* ev)
 
   if(event_id%everyNevents == 0 && event_id > 0) {
 
+    G4AutoLock lock(&outputMutex);
+    
     std::ios::fmtflags f( G4cout.flags() );
     G4int prec = G4cout.precision();
 
@@ -980,13 +988,13 @@ void EventAction::writeSim(long long int ts, PrimaryVertexInformation* primaryVe
 // --------------------------------------------------TB
 void EventAction::openEvfile()
 {
-  const auto fname = threadSuffixedFileName(outFileName);
-  if (!evfile.is_open()) evfile.open(fname.c_str());
+  
+  if (!evfile.is_open()) evfile.open(outFileName);
   if (!evfile.is_open()){
     G4cout<< "ERROR opening evfile." << G4endl;
     evOut = false;
   } else {
-    G4cout << "\nOpened output file: " << fname << G4endl;
+    G4cout << "\nOpened output file: " << outFileName << G4endl;
     evOut = true;
   }
   return;
@@ -1000,7 +1008,7 @@ void EventAction::closeEvfile()
 //----------------------------------------------------TB
 void EventAction::SetOutFile(G4String name)
 {
-  outFileName = name;
+  outFileName = threadSuffix(name);
   closeEvfile();
   openEvfile();
   return;
@@ -1008,14 +1016,13 @@ void EventAction::SetOutFile(G4String name)
 // --------------------------------------------------
 void EventAction::openMode2file()
 {
-  const auto fname = threadSuffixedFileName(mode2FileName);
-  mode2file = open(fname.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 
+  mode2file = open(mode2FileName.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 
 		   S_IRUSR | S_IWUSR | S_IRGRP |  S_IWGRP | S_IROTH);
   if(mode2file < 0){
     G4cout << "ERROR opening mode2file" << G4endl;
     mode2Out = false;
   } else {
-    G4cout << "\nOpened mode 2 Output file: " << fname << G4endl;
+    G4cout << "\nOpened mode 2 Output file: " << mode2FileName << G4endl;
     mode2Out = true;
   }
   return;
@@ -1029,7 +1036,7 @@ void EventAction::closeMode2file()
 //----------------------------------------------------
 void EventAction::SetMode2File(G4String name)
 {
-  mode2FileName = name;
+  mode2FileName = threadSuffix(name);
   openMode2file();
   return;
 }
@@ -1056,10 +1063,15 @@ void EventAction::SetCrmatFile(G4String name) {
 
   openCrmatFile();
 
+  const auto tid = G4Threading::G4GetThreadId();
+
+  if(tid == 0 ){ //only output on first worker thread
+  
   G4cout << "\nUsing crmat from file " << crmatFileName 
 	 << " to transform interaction points from world to crytsal frames."
 	 << G4endl;
-
+  }
+  
   int size;
   size = read(crmatFile, (char *) crmat, sizeof(crmat));
 
@@ -1070,8 +1082,12 @@ void EventAction::SetCrmatFile(G4String name) {
     exit(EXIT_FAILURE);
   }
 
+  if(tid == 0 ){
+  
   G4cout << "Read " << size << " bytes into crmat" << G4endl;
 
+  }
+  
   if(print){
     for(int i=0;i<MAXDETPOS;i++){
       for(int j=0;j<MAXCRYSTALNO;j++){
@@ -1094,44 +1110,55 @@ void EventAction::SetGretinaCoords(){
 
   gretinaCoords = true; 
 
+  const auto tid = G4Threading::G4GetThreadId();
+
+  if(tid == 0){ //only output on first worker thread
+
   G4cout << "Writing interaction points in the Gretina coordinate system (x = down, z = beam)." << G4endl;
 
+  }
+  
   return;
 }
 //---------------------------------------------------
  
 void EventAction::SetCrystalXforms(){ 
 
-  crystalXforms = true; 
+  crystalXforms = true;
+
+  const auto tid = G4Threading::G4GetThreadId();
+
+  if(tid == 0){ //only output on first worker thread
 
   G4cout << "Using internal transformations from the world frame to the crystal frames for Mode 2 output." << G4endl;
 
+  }
+  
   return;
 }
 //---------------------------------------------------
 void EventAction::openCacheOutputFile(G4String FileName)
 {
-  cacheOutputFileName = FileName;
-  const auto fname = threadSuffixedFileName(cacheOutputFileName);
+  cacheOutputFileName = threadSuffix(FileName);
 #ifdef CACHETEXT
   if (!cacheOutputFile.is_open())
-    cacheOutputFile.open(fname.c_str());
+    cacheOutputFile.open(cacheOutputFileName.c_str());
   if (!cacheOutputFile.is_open()){
     G4cerr << "Error opening cache output file." << G4endl;
     exit(EXIT_FAILURE);
   } else {
-    G4cout << "\nOpened cache output file: " << fname
+    G4cout << "\nOpened cache output file: " << cacheOutputFileName
 	   << G4endl;
     cacheOut = true;
     allS800 = true;
   }
 #else
-  cacheOutputFile = fopen(fname.c_str(), "wb");
+  cacheOutputFile = fopen(cacheOutputFileName.c_str(), "wb");
   if (cacheOutputFile == NULL) {
     G4cerr << "Error opening cache output file." << G4endl;
     exit(EXIT_FAILURE);
   } else {
-    G4cout << "\nOpened cache output file: " << fname
+    G4cout << "\nOpened cache output file: " << cacheOutputFileName
 	   << G4endl;
     cacheOut = true;
     allS800 = true;

--- a/src/EventAction.cc
+++ b/src/EventAction.cc
@@ -1,6 +1,8 @@
 #include "EventAction.hh"
 #include "RunAction.hh"
 
+#include <string>
+
 #include "G4Timer.hh"
 extern G4Timer Timerintern;
 
@@ -38,12 +40,38 @@ EventAction::EventAction()
   everyNevents = 1000;
   threshE = 0.;
   threshDE = 0.001*keV;
+
+  // Pre-size large scratch buffers used by writeDecomp(). Keeping these off the
+  // stack avoids thread stack overflows (macOS worker threads have small stacks).
+  fCrysIps.resize(100*MAX_INTPTS);
+  fCrysGts.resize((100*MAX_INTPTS)*MAX_INTPTS);
+  fProcessed.resize(100*MAX_INTPTS);
 }
 
 
 EventAction::~EventAction()
 {
   ;
+}
+
+G4String EventAction::threadSuffixedFileName(const G4String& baseName) const {
+  if (baseName.empty()) return baseName;
+
+  // Geant4 MT worker id (typically 0..N-1). We use -1 for master.
+  const auto tid = G4Threading::G4GetThreadId();
+  const G4String suffix = "_t" + std::to_string(tid);
+
+  // Insert suffix before the last '.' in the basename.
+  const std::string s = baseName;
+  const auto slash = s.find_last_of("/\\");
+  const auto dot = s.find_last_of('.');
+  const bool hasExt = (dot != std::string::npos) && (slash == std::string::npos || dot > slash);
+
+  if (!hasExt) {
+    return baseName + suffix;
+  }
+
+  return s.substr(0, dot) + suffix + s.substr(dot);
 }
 
 void EventAction::BeginOfEventAction(const G4Event* ev)
@@ -696,16 +724,18 @@ void EventAction::writeDecomp(long long int ts,
 {
   G4int siz;
   GEBDATA gd;
-  CRYS_IPS crys_ips[100*MAX_INTPTS];
-  G4double crys_gts[100*MAX_INTPTS][MAX_INTPTS];
+  // NOTE: these scratch buffers are stored on EventAction (heap) to avoid
+  // overflowing the worker thread stack.
+  auto* crys_ips = fCrysIps.data();
+  auto* crys_gts = fCrysGts.data(); // flattened [decomp*MAX_INTPTS + ip]
   
   G4int Ndecomp = 0;
-  G4bool Processed[100*MAX_INTPTS];
+  auto* Processed = fProcessed.data();
   for(G4int i = 0; i < NIP; i++)
-    Processed[i] = false;
+    Processed[i] = 0;
 
   for(G4int i = 0; i < NIP; i++){
-    if( NCons[i] > 0 && Processed[i] == false ){
+    if( NCons[i] > 0 && Processed[i] == 0 ){
 
       crys_ips[Ndecomp].type = 0xABCD5678;
       crys_ips[Ndecomp].crystal_id = detNum[i]+4; // +4 to match measured data
@@ -731,8 +761,8 @@ void EventAction::writeDecomp(long long int ts,
       crys_ips[Ndecomp].ips[ crys_ips[Ndecomp].num-1 ].e = e[i];
       crys_ips[Ndecomp].ips[ crys_ips[Ndecomp].num-1 ].seg = segNum[i];
       crys_ips[Ndecomp].ips[ crys_ips[Ndecomp].num-1 ].seg_ener = se[i];
-      crys_gts[Ndecomp][ crys_ips[Ndecomp].num-1 ] = gt[i];
-      Processed[i] = true;
+      crys_gts[Ndecomp*MAX_INTPTS + (crys_ips[Ndecomp].num-1)] = gt[i];
+      Processed[i] = 1;
 
       for(G4int j = i+1; j < MAX_INTPTS; j++){ // Clear the interaction points
 	  crys_ips[Ndecomp].ips[j].x        = 0.;
@@ -746,7 +776,7 @@ void EventAction::writeDecomp(long long int ts,
       // Get other interactions with this crystal
       for(G4int j = i+1; j < NIP; j++){ 
 	if(NCons[j] > 0 && 
-	   Processed[j] == false &&
+	   Processed[j] == 0 &&
 	   detNum[j]+4 == crys_ips[Ndecomp].crystal_id){
 	  crys_ips[Ndecomp].tot_e += e[j];
 	  // Only MAX_INTPTS interaction points can be stored in a crys_ips.
@@ -757,10 +787,10 @@ void EventAction::writeDecomp(long long int ts,
 	    crys_ips[Ndecomp].ips[ crys_ips[Ndecomp].num ].e = e[j];
 	    crys_ips[Ndecomp].ips[ crys_ips[Ndecomp].num ].seg = segNum[j];
 	    crys_ips[Ndecomp].ips[ crys_ips[Ndecomp].num ].seg_ener = se[j];
-	    crys_gts[Ndecomp][ crys_ips[Ndecomp].num ] = gt[j];
+	    crys_gts[Ndecomp*MAX_INTPTS + crys_ips[Ndecomp].num] = gt[j];
 	  }
 	  crys_ips[Ndecomp].num++; // Check for overflow below, and warn.
-	  Processed[j] = true;
+	  Processed[j] = 1;
 	}
       }
       Ndecomp++;
@@ -779,10 +809,10 @@ void EventAction::writeDecomp(long long int ts,
 	ips[j].x        = crys_ips[i].ips[j].x;
 	ips[j].y        = crys_ips[i].ips[j].y;
 	ips[j].z        = crys_ips[i].ips[j].z;
-	ips[j].e        = crys_ips[i].ips[j].e;
-	ips[j].seg      = crys_ips[i].ips[j].seg;
-	ips[j].seg_ener = crys_ips[i].ips[j].seg_ener;
-	gts[j]          = crys_gts[i][j];
+	  ips[j].e        = crys_ips[i].ips[j].e;
+	  ips[j].seg      = crys_ips[i].ips[j].seg;
+	  ips[j].seg_ener = crys_ips[i].ips[j].seg_ener;
+	  gts[j]          = crys_gts[i*MAX_INTPTS + j];
       }
     
       // G4cout << "=========================" << G4endl;
@@ -799,7 +829,7 @@ void EventAction::writeDecomp(long long int ts,
     
       // Time-sort the indices of the interaction points
       // (credit: https://stackoverflow.com/a/40183830)
-      std::sort(idx.begin(), idx.end(), [&](int k,int l){return crys_gts[i][k] < crys_gts[i][l];} );
+      std::sort(idx.begin(), idx.end(), [&](int k,int l){return crys_gts[i*MAX_INTPTS + k] < crys_gts[i*MAX_INTPTS + l];} );
 
       // Use the time-sorted indices to re-order the interaction points.
       for(G4int j = 0; j < crys_ips[i].num; j++){
@@ -809,7 +839,7 @@ void EventAction::writeDecomp(long long int ts,
 	crys_ips[i].ips[j].e        = ips[idx[j]].e;
 	crys_ips[i].ips[j].seg      = ips[idx[j]].seg;
 	crys_ips[i].ips[j].seg_ener = ips[idx[j]].seg_ener;
-	crys_gts[i][j]              = gts[idx[j]];
+	crys_gts[i*MAX_INTPTS + j]  = gts[idx[j]];
       }
 
       // G4cout << "After:" << G4endl;
@@ -872,7 +902,7 @@ void EventAction::writeDecomp(long long int ts,
 	       << crys_ips[i].ips[j].x << std::setw(12) 
 	       << crys_ips[i].ips[j].y << std::setw(12) 
 	       << crys_ips[i].ips[j].z << std::setw(12)
-	       << crys_gts[i][j]
+	       << crys_gts[i*MAX_INTPTS + j]
 	       << G4endl;
       }
     }
@@ -950,12 +980,13 @@ void EventAction::writeSim(long long int ts, PrimaryVertexInformation* primaryVe
 // --------------------------------------------------TB
 void EventAction::openEvfile()
 {
-  if (!evfile.is_open()) evfile.open(outFileName.c_str());
+  const auto fname = threadSuffixedFileName(outFileName);
+  if (!evfile.is_open()) evfile.open(fname.c_str());
   if (!evfile.is_open()){
     G4cout<< "ERROR opening evfile." << G4endl;
     evOut = false;
   } else {
-    G4cout << "\nOpened output file: " << outFileName << G4endl;
+    G4cout << "\nOpened output file: " << fname << G4endl;
     evOut = true;
   }
   return;
@@ -977,13 +1008,14 @@ void EventAction::SetOutFile(G4String name)
 // --------------------------------------------------
 void EventAction::openMode2file()
 {
-  mode2file = open(mode2FileName.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 
+  const auto fname = threadSuffixedFileName(mode2FileName);
+  mode2file = open(fname.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 
 		   S_IRUSR | S_IWUSR | S_IRGRP |  S_IWGRP | S_IROTH);
   if(mode2file < 0){
     G4cout << "ERROR opening mode2file" << G4endl;
     mode2Out = false;
   } else {
-    G4cout << "\nOpened mode 2 Output file: " << mode2FileName << G4endl;
+    G4cout << "\nOpened mode 2 Output file: " << fname << G4endl;
     mode2Out = true;
   }
   return;
@@ -1080,25 +1112,26 @@ void EventAction::SetCrystalXforms(){
 void EventAction::openCacheOutputFile(G4String FileName)
 {
   cacheOutputFileName = FileName;
+  const auto fname = threadSuffixedFileName(cacheOutputFileName);
 #ifdef CACHETEXT
   if (!cacheOutputFile.is_open())
-    cacheOutputFile.open(cacheOutputFileName.c_str());
+    cacheOutputFile.open(fname.c_str());
   if (!cacheOutputFile.is_open()){
     G4cerr << "Error opening cache output file." << G4endl;
     exit(EXIT_FAILURE);
   } else {
-    G4cout << "\nOpened cache output file: " << cacheOutputFileName
+    G4cout << "\nOpened cache output file: " << fname
 	   << G4endl;
     cacheOut = true;
     allS800 = true;
   }
 #else
-  cacheOutputFile = fopen(cacheOutputFileName.c_str(), "wb");
+  cacheOutputFile = fopen(fname.c_str(), "wb");
   if (cacheOutputFile == NULL) {
     G4cerr << "Error opening cache output file." << G4endl;
     exit(EXIT_FAILURE);
   } else {
-    G4cout << "\nOpened cache output file: " << cacheOutputFileName
+    G4cout << "\nOpened cache output file: " << fname
 	   << G4endl;
     cacheOut = true;
     allS800 = true;

--- a/src/Gretina_Array.cc
+++ b/src/Gretina_Array.cc
@@ -152,10 +152,13 @@ Gretina_Array::~Gretina_Array()
 void Gretina_Array::Placement()
 {
 
+  ///// Prep for ConstructSDandField()
   // Sensitive Detector
-  G4RunManager* runManager = G4RunManager::GetRunManager();
-  DetectorConstruction* theDetector  = (DetectorConstruction*) runManager->GetUserDetectorConstruction();
-
+  // G4RunManager* runManager = G4RunManager::GetRunManager();
+  // DetectorConstruction* theDetector  = (DetectorConstruction*) runManager->GetUserDetectorConstruction();
+  //////
+  
+  
   ReadSolidFile();
   ReadClustFile();
   ReadWallsFile();
@@ -172,14 +175,17 @@ void Gretina_Array::Placement()
 
   ConstructTheCapsules();
 
-  G4int depth;
-  if(makeCapsule)
-    depth = 2;
-  else
-    depth = 1;
+  ////// Prep for ConstructSDandField()
+  // G4int depth;
+  // if(makeCapsule)
+  //   depth = 2;
+  // else
+  //   depth = 1;
 
-  theDetector->GetGammaSD()->SetDepth(depth);
+  // theDetector->GetGammaSD()->SetDepth(depth);
+  //////////
 
+  
   ConstructTheClusters();
   PlaceTheClusters();
 
@@ -1254,7 +1260,6 @@ void Gretina_Array::ConstructGeCrystals()
 
     pPg->pDetL->SetVisAttributes( pPg->pDetVA );
     //    pPg->pDetL->SetSensitiveDetector( theDetector->GeSD() );
-    pPg->pDetL->SetSensitiveDetector( theDetector->GetGammaSD() );
     ngen++;
 
     G4double totalV = pPg->pCaps->GetCubicVolume()/cm3;

--- a/src/Outgoing_Beam.cc
+++ b/src/Outgoing_Beam.cc
@@ -2,6 +2,20 @@
 #include "G4DecayTable.hh"
 #include "G4Decay.hh"
 #include "G4RadioactiveDecay.hh"
+
+// Thread-local transient reaction state (see Outgoing_Beam.hh).
+G4ThreadLocal G4int Outgoing_Beam::Ain = 0;
+G4ThreadLocal G4int Outgoing_Beam::Zin = 0;
+G4ThreadLocal G4ThreeVector Outgoing_Beam::dirIn;
+G4ThreadLocal G4ThreeVector Outgoing_Beam::posIn;
+G4ThreadLocal G4ThreeVector Outgoing_Beam::posOut;
+G4ThreadLocal G4ThreeVector Outgoing_Beam::pIn;
+G4ThreadLocal G4int Outgoing_Beam::ReactionFlag = -1;
+G4ThreadLocal G4int Outgoing_Beam::ThresholdFlag = 0;
+G4ThreadLocal G4double Outgoing_Beam::KEIn = 0.;
+G4ThreadLocal G4double Outgoing_Beam::ET = 0.;
+G4ThreadLocal G4double Outgoing_Beam::p1 = 0.;
+G4ThreadLocal G4double Outgoing_Beam::sin2theta3_max = 0.;
 #include "G4ProcessManager.hh"
 
 Outgoing_Beam::Outgoing_Beam()

--- a/src/PrimaryGeneratorAction.cc
+++ b/src/PrimaryGeneratorAction.cc
@@ -226,7 +226,10 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
       
       // Z position of the reaction point
       depth=TC+TT*(G4UniformRand()-0.5);
-      myDetector->setTargetReactionDepth(depth);
+      // Store per-event reaction depth on the primary vertex info.
+      // In MT runs, using a shared Target UserLimits here causes cross-thread
+      // races (one event's depth affects another).
+      const G4double reactionDepthZ = depth;
 
       // G4cout << "**** center = " << TC
       // 	     << ", direction = " << direction
@@ -239,6 +242,7 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
       PrimaryVertexInformation* primaryVertexInfo
 	= new PrimaryVertexInformation;
       anEvent->GetPrimaryVertex()->SetUserInformation(primaryVertexInfo);
+      primaryVertexInfo->SetReactionDepthZ(reactionDepthZ);
 
     }
   else if(cache)

--- a/src/PrimaryGeneratorAction.cc
+++ b/src/PrimaryGeneratorAction.cc
@@ -47,6 +47,14 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
   particleTable = G4ParticleTable::GetParticleTable();
   ionTable = G4IonTable::GetIonTable();
   BeamOut->SetReactionFlag(-1);
+
+#ifdef SCANNING
+  // Keep per-thread generator state in sync with the scan-table controller.
+  // Doing this here (instead of DetectorConstruction) avoids MT crashes where
+  // the generator action is not yet constructed during geometry setup.
+  sourcePosition.setX(-myDetector->GetScanningTableControllerX());
+  sourcePosition.setZ( myDetector->GetScanningTableControllerY());
+#endif
   
   if(source)
     {

--- a/src/PrimaryVertexInformation.cc
+++ b/src/PrimaryVertexInformation.cc
@@ -15,6 +15,8 @@ PrimaryVertexInformation::PrimaryVertexInformation() {
   fExitPhi        = sqrt(-1.0);
   ffiltercode     = 0;
   fwrite          = true;
+  fHasReactionDepthZ = false;
+  fReactionDepthZ = 0.0;
 }
 
 void PrimaryVertexInformation::AddEmittedGamma(G4double e, 

--- a/src/Reaction.cc
+++ b/src/Reaction.cc
@@ -1,6 +1,9 @@
 #include "Reaction.hh"
 #include "Reaction_Messenger.hh"
 
+#include "G4RunManager.hh"
+#include "PrimaryVertexInformation.hh"
+
 Reaction::Reaction(Outgoing_Beam* BO, const G4String& aName)
   : G4VProcess(aName), BeamOut(BO)
 {
@@ -200,7 +203,24 @@ G4double Reaction::PostStepGetPhysicalInteractionLength(
       return 0;
     }
 
-    G4double ZReaction=pUserLimits->GetUserMinRange(aTrack);
+    // In MT, the reaction depth must be per-event. Prefer PrimaryVertexInformation
+    // (set by PrimaryGeneratorAction) and fall back to UserLimits if absent.
+    G4double ZReaction = 0.0;
+    bool haveDepth = false;
+
+    if (auto* evt = G4RunManager::GetRunManager()->GetCurrentEvent()) {
+      if (auto* pv = evt->GetPrimaryVertex()) {
+        auto* info = static_cast<PrimaryVertexInformation*>(pv->GetUserInformation());
+        if (info && info->HasReactionDepthZ()) {
+          ZReaction = info->GetReactionDepthZ();
+          haveDepth = true;
+        }
+      }
+    }
+
+    if (!haveDepth && pUserLimits) {
+      ZReaction = pUserLimits->GetUserMinRange(aTrack);
+    }
     G4double ZCurrent=aTrack.GetPosition().getZ();
     G4double Z=ZReaction-ZCurrent;
     if(Z<0){

--- a/src/RunAction.cc
+++ b/src/RunAction.cc
@@ -17,23 +17,12 @@ RunAction::~RunAction()
 void RunAction::BeginOfRunAction(const G4Run* run)
 {
 
+  if(G4Threading::IsMasterThread()){
+    
   G4cout<<" Beginning of run "<<G4endl;
-
-  evaction->SetNTotalevents(run->GetNumberOfEventToBeProcessed());
-  if(run->GetNumberOfEventToBeProcessed() > 1000000)
-    evaction->SetEveryNEvents(10000);
-  else if(run->GetNumberOfEventToBeProcessed() > 1000)
-    evaction->SetEveryNEvents(1000);
-  else if(run->GetNumberOfEventToBeProcessed() > 100)
-    evaction->SetEveryNEvents(100);
-  else
-    evaction->SetEveryNEvents(1);
 
   G4cout << " Simulating " << run->GetNumberOfEventToBeProcessed()
 	 << " events." << G4endl;
-
-  if(BeamIn->getKE()>0)
-    evaction->SetInBeam(true);
   
   if(evaction->EvOut())
     G4cout << " Writing ASCII output to " 
@@ -79,6 +68,23 @@ void RunAction::BeginOfRunAction(const G4Run* run)
     }
   }
   Timer.Start();
+
+  }
+
+  evaction->SetNTotalevents(run->GetNumberOfEventToBeProcessed());
+  if(run->GetNumberOfEventToBeProcessed() > 1000000)
+    evaction->SetEveryNEvents(10000);
+  else if(run->GetNumberOfEventToBeProcessed() > 1000)
+    evaction->SetEveryNEvents(1000);
+  else if(run->GetNumberOfEventToBeProcessed() > 100)
+    evaction->SetEveryNEvents(100);
+  else
+    evaction->SetEveryNEvents(1);
+
+  if(BeamIn->getKE()>0)
+    evaction->SetInBeam(true);
+
+  
 }
 
 
@@ -94,6 +100,8 @@ void RunAction::EndOfRunAction(const G4Run*)
   if(evaction->CacheIn())
     evaction->closeCacheInputFile();
 
+  if(G4Threading::IsMasterThread()){
+    
   Timer.Stop();
 
   G4cout << "                                                     " << G4endl;
@@ -169,6 +177,8 @@ void RunAction::EndOfRunAction(const G4Run*)
   G4cout << "   "
 	 << evaction->GetNTotalevents()/Timer.GetRealElapsed()
 	 << " events/s" << G4endl;
- 
+
+  }
+  
 }
 

--- a/src/Target.cc
+++ b/src/Target.cc
@@ -1,6 +1,8 @@
 #ifndef LHTARGET
 #include "Target.hh"
 
+#include "G4RunManager.hh"
+
 Target::Target()
 {
   buildSled=false;
@@ -56,6 +58,8 @@ G4VPhysicalVolume* Target::Construct(G4LogicalVolume* experimentalHall_log)
   Target_log->SetVisAttributes(Vis_6);
 
   if(buildSled) BuildSled();
+
+  if(sourceFrame != "") BuildSourceFrame();
 
   return Target_phys;
 }
@@ -131,15 +135,23 @@ void Target::setPosition(G4double x, G4double y, G4double z)
 //---------------------------------------------------------------------
 void Target::setSourceFrame(G4String sF)
 {
-  if(Target_phys)
-    delete Target_phys;
-  
   sourceFrame = sF;
 
+  // If the geometry has already been constructed (e.g. user calls this after
+  // /run/initialize), force a rebuild so MT worker threads see the new geometry
+  // before /run/beamOn.
+  if(Target_phys && G4RunManager::GetRunManager()) {
+    G4RunManager::GetRunManager()->ReinitializeGeometry();
+  }
+}
+
+//---------------------------------------------------------------------
+void Target::BuildSourceFrame()
+{
   if(sourceFrame == "eu152_Z2707"){
 
     frameMaterial = G4Material::GetMaterial("Al");
-    //    frameThickness = 2.9*mm; // Used prior to 3/2012
+    // frameThickness = 2.9*mm; // Used prior to 3/2012
     frameThickness = 1.2*mm;       // Dirk Weisshaar 3/4/2012
     frameInnerRadius = 3.8*cm/2.0; // Source data sheet
     frameOuterRadius = 5.4*cm/2.0; // Source data sheet
@@ -188,10 +200,12 @@ void Target::setSourceFrame(G4String sF)
     coFrame = new G4Box("coFrame", frameSide_x/2., frameSide_y/2., frameThickness/2.);
     coFrame_log = new G4LogicalVolume(coFrame,frameMaterial,"coFrame_log",0,0,0);
     coFrame_phys = new G4PVPlacement(G4Transform3D(NoRot,*Pos),coFrame_log,"coFrame",expHall_log,false,0);
-
+  } else {
+    G4cout<<"----> Warning: unknown source frame '"<<sourceFrame<<"' (no frame will be built)."<< G4endl;
+    return;
   }
 
-  G4cout<<"----> Including source frame: "<<sourceFrame<< G4endl;                 
+  G4cout<<"----> Including source frame: "<<sourceFrame<< G4endl;
 }
 //-------------------------------------------------------------------
 void Target::BuildSled()

--- a/src/Target_LH.cc
+++ b/src/Target_LH.cc
@@ -1,6 +1,8 @@
 #ifdef LHTARGET
 #include "Target_LH.hh"
 
+#include "G4RunManager.hh"
+
 Target::Target()
 {
   buildSled=false;
@@ -90,6 +92,8 @@ G4VPhysicalVolume* Target::Construct(G4LogicalVolume* experimentalHall_log)
   LHTarget->MakeImprint(expHall_log, *Pos, &LHTargetRot);
 
   if(buildSled) BuildSled();
+
+  if(sourceFrame != "") BuildSourceFrame();
 
   return Target_phys;
 
@@ -1053,6 +1057,14 @@ void Target::setSourceFrame(G4String sF)
 {
   sourceFrame = sF;
 
+  if(Target_phys && G4RunManager::GetRunManager()) {
+    G4RunManager::GetRunManager()->ReinitializeGeometry();
+  }
+}
+
+//---------------------------------------------------------------------
+void Target::BuildSourceFrame()
+{
   if(sourceFrame == "eu152_Z2707"){
 
     frameMaterial = G4Material::GetMaterial("Al");
@@ -1062,7 +1074,7 @@ void Target::setSourceFrame(G4String sF)
     tapeMaterial = G4Material::GetMaterial("G4_POLYETHYLENE");
     tapeThickness = 0.012*cm;
 
-    tape_r = frameInnerRadius - .2*cm; //in order to remove overlap
+    tape_r = frameInnerRadius - .2*cm; // in order to remove overlap
 
     euFrame = new G4Tubs("euFrame",frameInnerRadius,frameOuterRadius,frameThickness/2.,0.,360.*deg);
     euFrame_log = new G4LogicalVolume(euFrame,frameMaterial,"euFrame_log",0,0,0);
@@ -1096,9 +1108,12 @@ void Target::setSourceFrame(G4String sF)
     csTape_log = new G4LogicalVolume(csTape,tapeMaterial,"csTape_log",0,0,0);
     csTape_phys = new G4PVPlacement(G4Transform3D(NoRot,*Pos),csTape_log,"csTape",expHall_log,false,0);
 
+  } else {
+    G4cout<<"----> Warning: unknown source frame '"<<sourceFrame<<"' (no frame will be built)."<< G4endl;
+    return;
   }
 
-  G4cout<<"----> Source frame is set to "<<sourceFrame<< G4endl;                 
+  G4cout<<"----> Including source frame: "<<sourceFrame<< G4endl;
 }
 //-------------------------------------------------------------------
 void Target::BuildSled()

--- a/src/TrackerGammaHit.cc
+++ b/src/TrackerGammaHit.cc
@@ -6,7 +6,7 @@
 #include "G4Colour.hh"
 #include "G4VisAttributes.hh"
 
-G4Allocator<TrackerGammaHit> TrackerGammaHitAllocator;
+G4ThreadLocal G4Allocator<TrackerGammaHit>* TrackerGammaHitAllocator = nullptr;
 
 
 TrackerGammaHit::TrackerGammaHit() {}
@@ -123,4 +123,3 @@ void TrackerGammaHit::Print()
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
-

--- a/src/TrackerGammaSD.cc
+++ b/src/TrackerGammaSD.cc
@@ -24,6 +24,7 @@ TrackerGammaSD::TrackerGammaSD(G4String name)
   phdA = 0.21;
   phdB = 1.099;
   posRes = 0.;
+  fHCID = -1;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -279,12 +280,11 @@ void TrackerGammaSD::EndOfEvent(G4HCofThisEvent* HCE)
 	  }
 
 
-  static G4int HCID = -1;
-  if(HCID<0)
-  { HCID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]); }
-  HCE->AddHitsCollection( HCID, gammaCollection ); 
- }
+  if(fHCID < 0) {
+    fHCID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]);
+  }
+  HCE->AddHitsCollection(fHCID, gammaCollection);
+  }
 
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
-

--- a/src/TrackerIonHit.cc
+++ b/src/TrackerIonHit.cc
@@ -1,7 +1,7 @@
 
 #include "TrackerIonHit.hh"
 
-G4Allocator<TrackerIonHit> TrackerIonHitAllocator;
+G4ThreadLocal G4Allocator<TrackerIonHit>* TrackerIonHitAllocator = nullptr;
 
 
 TrackerIonHit::TrackerIonHit() { flag=0;}
@@ -84,4 +84,3 @@ void TrackerIonHit::Print()
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
-

--- a/src/TrackerIonSD.cc
+++ b/src/TrackerIonSD.cc
@@ -7,7 +7,8 @@ TrackerIonSD::TrackerIonSD(G4String name)
   G4String HCname;
   collectionName.insert(HCname="ionCollection");
   print=false; //LR (formerly not initialized)
- 
+
+  
 }
 
 //--------------------------------------------------------------------
@@ -19,12 +20,14 @@ TrackerIonSD::TrackerIonSD(G4String name)
 
 //--------------------------------------------------------------------
 
-void TrackerIonSD::Initialize(G4HCofThisEvent*)
+void TrackerIonSD::Initialize(G4HCofThisEvent* hce)
 { 
  
 
     ionCollection = new TrackerIonHitsCollection
-                          (SensitiveDetectorName,collectionName[0]);  
+                          (SensitiveDetectorName,collectionName[0]);
+
+    
   
 }
 //--------------------------------------------------------------------

--- a/src/TrackerIonSD.cc
+++ b/src/TrackerIonSD.cc
@@ -2,7 +2,7 @@
 
 //--------------------------------------------------------------------
 TrackerIonSD::TrackerIonSD(G4String name)
-  :G4VSensitiveDetector(name)
+  :G4VSensitiveDetector(name), fHCID(-1)
 {
   G4String HCname;
   collectionName.insert(HCname="ionCollection");
@@ -173,12 +173,11 @@ void TrackerIonSD::EndOfEvent(G4HCofThisEvent* HCE)
      
     }  
  
- static G4int HCID = -1;
-  if(HCID<0)
-  { HCID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]); }
-  HCE->AddHitsCollection( HCID, ionCollection ); 
- }
+  if(fHCID < 0) {
+    fHCID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]);
+  }
+  HCE->AddHitsCollection(fHCID, ionCollection);
+  }
 
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
-


### PR DESCRIPTION
**Enabling MT-support**

1. Refactored the sensitive detectors by creating necessary DetectorConstruction::ConstructSDandField() and moving calls there
2.  Added the foundations for running geant4 with multithreading turned on. 
     a. Created required ActionInitialization class
     b. Made senstitive detector classes thread-safe
3. Thread-locked and split the outputs to be thread-safe. 
 
I did not test if it will compile and run with geant4 MT turned off. If there are issues the MT components can be guarded, especially in the main files (e.g. UCGretina.cc). It is common in the geant4 examples to #ifdef MT and simply change between G4MTRunManager & G4RunManager. 

If you prefer I can implement this myself and resubmit the PR when it compiles and runs w/ & w/out MT support.   