### PR TITLE
added thread-safe stopwatch so time remaining and event rate is accurate

### DIFF
--- a/include/ActionInitialization.hh
+++ b/include/ActionInitialization.hh
@@ -2,6 +2,7 @@
 #define ActionInitialization_h 1
 
 #include "G4VUserActionInitialization.hh"
+#include "Stopwatch.hh"
 
 class DetectorConstruction;
 class Incoming_Beam;
@@ -14,7 +15,7 @@ public:
                        Incoming_Beam* beamIn,
                        Outgoing_Beam* beamOut,
                        bool enableStepping);
-  ~ActionInitialization() override = default;
+  ~ActionInitialization() override {delete stopwatch.Timer;}
 
   void BuildForMaster() const override;
   void Build() const override;
@@ -24,6 +25,8 @@ private:
   Incoming_Beam* fBeamIn;
   Outgoing_Beam* fBeamOut;
   bool fEnableStepping;
+
+  mutable Stopwatch stopwatch;
 };
 
 #endif

--- a/include/EventAction.hh
+++ b/include/EventAction.hh
@@ -99,11 +99,14 @@ class EventAction : public G4UserEventAction
     G4int GetNTotalevents(){return NTotalEvents;}
     void SetEveryNEvents(G4int n){everyNevents = n;}
     G4int GetEveryNEvents(){return everyNevents;}
+    G4int GetCompletedEvents(){return CompletedEvents;}
 
     void SetPosRes(G4double res){posRes = res;}
     void SetThreshE(G4double e){threshE = e;}
     void SetThreshDE(G4double de){threshDE = de;}
     void SetStopwatch(Stopwatch* sp){stopwatch = sp;}
+
+    G4String GetCacheOutputFilename(){return cacheOutputFileName;}
   
   private:
     G4String threadSuffix(const G4String& baseName) const;
@@ -155,6 +158,7 @@ class EventAction : public G4UserEventAction
     G4bool fisInBeam;
     G4bool timeSort;
     G4int NTotalEvents;
+    G4int CompletedEvents;
     G4double posRes;
     G4double threshE;
     G4double threshDE;

--- a/include/EventAction.hh
+++ b/include/EventAction.hh
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "G4Threading.hh"
+#include "Stopwatch.hh"
 
 class EventAction : public G4UserEventAction
 {
@@ -102,6 +103,7 @@ class EventAction : public G4UserEventAction
     void SetPosRes(G4double res){posRes = res;}
     void SetThreshE(G4double e){threshE = e;}
     void SetThreshDE(G4double de){threshDE = de;}
+    void SetStopwatch(Stopwatch* sp){stopwatch = sp;}
   
   private:
     G4String threadSuffix(const G4String& baseName) const;
@@ -156,6 +158,8 @@ class EventAction : public G4UserEventAction
     G4double posRes;
     G4double threshE;
     G4double threshDE;
+
+    Stopwatch* stopwatch;
   
     G4int timerCount;
     G4int everyNevents;

--- a/include/Git_Hash.hh
+++ b/include/Git_Hash.hh
@@ -1,5 +1,5 @@
 #ifndef Git_Hash_h
 #define Git_Hash_h
-#define GIT_HASH "6c7bfe"
+#define GIT_HASH "77c692"
 #define GIT_BRANCH "stopwatch"
 #endif

--- a/include/Git_Hash.hh
+++ b/include/Git_Hash.hh
@@ -1,5 +1,5 @@
 #ifndef Git_Hash_h
 #define Git_Hash_h
-#define GIT_HASH "c262e5"
-#define GIT_BRANCH "geant4.10"
+#define GIT_HASH "6c7bfe"
+#define GIT_BRANCH "stopwatch"
 #endif

--- a/include/Git_Hash.hh
+++ b/include/Git_Hash.hh
@@ -1,5 +1,5 @@
 #ifndef Git_Hash_h
 #define Git_Hash_h
-#define GIT_HASH "321c05"
+#define GIT_HASH "d16eae"
 #define GIT_BRANCH "stopwatch"
 #endif

--- a/include/Git_Hash.hh
+++ b/include/Git_Hash.hh
@@ -1,5 +1,5 @@
 #ifndef Git_Hash_h
 #define Git_Hash_h
-#define GIT_HASH "77c692"
+#define GIT_HASH "321c05"
 #define GIT_BRANCH "stopwatch"
 #endif

--- a/include/Stopwatch.hh
+++ b/include/Stopwatch.hh
@@ -1,0 +1,11 @@
+#pragma once
+#include "G4Timer.hh"
+#include <atomic>
+
+struct Stopwatch{
+  G4int timerCount = 0;
+  G4Timer* Timer = nullptr;
+  G4double rate = 0;
+  std::atomic<G4int> completedEvents{0};
+  
+};

--- a/src/ActionInitialization.cc
+++ b/src/ActionInitialization.cc
@@ -16,20 +16,24 @@ ActionInitialization::ActionInitialization(DetectorConstruction* detector,
                                            Incoming_Beam* beamIn,
                                            Outgoing_Beam* beamOut,
                                            bool enableStepping)
-  : fDetector(detector), fBeamIn(beamIn), fBeamOut(beamOut), fEnableStepping(enableStepping) {}
+  : fDetector(detector), fBeamIn(beamIn), fBeamOut(beamOut), fEnableStepping(enableStepping){
+  stopwatch.Timer = new G4Timer();
+}
 
 void ActionInitialization::BuildForMaster() const {
   // Master does not process events; keep it minimal.
   G4cout << "Building Master" << G4endl;
   auto* eventAction = new EventAction();
   SetUserAction(new RunAction(fDetector, fBeamIn, eventAction));
+  stopwatch.Timer->Start();
 }
 
 void ActionInitialization::Build() const {
   auto* eventAction = new EventAction();
   SetUserAction(eventAction);
   (void)new EventAction_Messenger(eventAction);
-
+  eventAction->SetStopwatch(&stopwatch);
+  
   auto* generatorAction = new PrimaryGeneratorAction(fDetector, fBeamIn, fBeamOut);
   SetUserAction(generatorAction);
   (void)new PrimaryGeneratorAction_Messenger(generatorAction);

--- a/src/ActionInitialization.cc
+++ b/src/ActionInitialization.cc
@@ -25,13 +25,13 @@ void ActionInitialization::BuildForMaster() const {
   G4cout << "Building Master" << G4endl;
   auto* eventAction = new EventAction();
   SetUserAction(new RunAction(fDetector, fBeamIn, eventAction));
-  stopwatch.Timer->Start();
 }
 
 void ActionInitialization::Build() const {
   auto* eventAction = new EventAction();
   SetUserAction(eventAction);
   (void)new EventAction_Messenger(eventAction);
+  stopwatch.Timer->Start();
   eventAction->SetStopwatch(&stopwatch);
   
   auto* generatorAction = new PrimaryGeneratorAction(fDetector, fBeamIn, fBeamOut);

--- a/src/EventAction.cc
+++ b/src/EventAction.cc
@@ -135,11 +135,11 @@ void EventAction::EndOfEventAction(const G4Event* ev)
     
     std::cout << std::fixed << std::setprecision(0) << std::setw(4) 
 	   << std::setfill(' ')
-	   << (float)event_id/NTotalEvents*100 << " %   "
+	   << (float)completed/NTotalEvents*100 << " %   "
 	   << eventsPerSecond << " events/s ";
 
     G4double hours, minutes, seconds;
-    G4double time = (float)(NTotalEvents - event_id)/eventsPerSecond;
+    G4double time = (float)(NTotalEvents - completed)/eventsPerSecond;
     hours = floor(time/3600.0);
     if(hours>0){
       std::cout << std::setprecision(0) << std::setw(2) 

--- a/src/EventAction.cc
+++ b/src/EventAction.cc
@@ -1,11 +1,10 @@
 #include "EventAction.hh"
 #include "RunAction.hh"
 
+
 #include <string>
 
 #include "G4Timer.hh"
-extern G4Timer Timerintern;
-
 #include "G4AutoLock.hh"
 
 namespace{
@@ -40,7 +39,6 @@ EventAction::EventAction()
   evt = NULL;
   fisInBeam = false;
   timeSort = false;
-  Timerintern.Start();
   timerCount = 0;
   eventsPerSecond = 0;
   everyNevents = 1000;
@@ -110,19 +108,32 @@ void EventAction::EndOfEventAction(const G4Event* ev)
 
   G4int event_id=evt->GetEventID();
 
-  if(event_id%everyNevents == 0 && event_id > 0) {
+  //Geant4 does not complete events in order on MT
+  //We need thread-safe atomic<int> to keep track of completed events
+  const G4int completed =
+    stopwatch->completedEvents.fetch_add(1, std::memory_order_relaxed) + 1;
+
+
+  if(completed%everyNevents == 0 && event_id > 0) {
 
     G4AutoLock lock(&outputMutex);
     
     std::ios::fmtflags f( G4cout.flags() );
     G4int prec = G4cout.precision();
 
-    Timerintern.Stop();
-    timerCount++;
-    eventsPerSecond += 
-      ((double)everyNevents/Timerintern.GetRealElapsed() 
-       - eventsPerSecond)/timerCount;
-    G4cout << std::fixed << std::setprecision(0) << std::setw(3) 
+    G4Timer* Timerintern = stopwatch->Timer;
+    
+    Timerintern->Stop();
+
+    G4double realtime = Timerintern->GetRealElapsed();
+
+    if(realtime>0){
+      stopwatch->timerCount = stopwatch->timerCount + 1;
+      stopwatch->rate += everyNevents/realtime;
+      eventsPerSecond = stopwatch->rate/double(stopwatch->timerCount);
+    }
+    
+    std::cout << std::fixed << std::setprecision(0) << std::setw(4) 
 	   << std::setfill(' ')
 	   << (float)event_id/NTotalEvents*100 << " %   "
 	   << eventsPerSecond << " events/s ";
@@ -131,29 +142,29 @@ void EventAction::EndOfEventAction(const G4Event* ev)
     G4double time = (float)(NTotalEvents - event_id)/eventsPerSecond;
     hours = floor(time/3600.0);
     if(hours>0){
-      G4cout << std::setprecision(0) << std::setw(2) 
+      std::cout << std::setprecision(0) << std::setw(2) 
 	     << hours << ":";
-      G4cout << std::setfill('0');
+      std::cout << std::setfill('0');
     } else {
-      G4cout << std::setfill(' ');
+      std::cout << std::setfill(' ');
     }
     minutes = floor(fmod(time,3600.0)/60.0);
     if(minutes>0){
-      G4cout << std::setprecision(0) << std::setw(2) << minutes << ":";
-      G4cout << std::setfill('0');
+      std::cout << std::setprecision(0) << std::setw(2) << minutes << ":";
+      std::cout << std::setfill('0');
     } else {
-      G4cout << std::setfill(' ');
+      std::cout << std::setfill(' ');
     }
     seconds = fmod(time,60.0);
     if(seconds>0)
-      G4cout << std::setprecision(0) << std::setw(2) << seconds;
-    G4cout << std::setfill(' ');
-    G4cout << " remaining       "
+      std::cout << std::setprecision(0) << std::setw(2) << seconds;
+    std::cout << std::setfill(' ');
+    std::cout << " remaining       "
 	   << "\r"<<std::flush;
-    Timerintern.Start();
+    Timerintern->Start();
 
-    G4cout.setf( f );
-    G4cout.precision( prec );
+    std::cout.setf( f );
+    std::cout.precision( prec );
 
   }
   

--- a/src/EventAction.cc
+++ b/src/EventAction.cc
@@ -44,7 +44,9 @@ EventAction::EventAction()
   everyNevents = 1000;
   threshE = 0.;
   threshDE = 0.001*keV;
-
+  NTotalEvents = 0;
+  CompletedEvents = 0;
+  
   // Pre-size large scratch buffers used by writeDecomp(). Keeping these off the
   // stack avoids thread stack overflows (macOS worker threads have small stacks).
   fCrysIps.resize(100*MAX_INTPTS);
@@ -113,7 +115,8 @@ void EventAction::EndOfEventAction(const G4Event* ev)
   const G4int completed =
     stopwatch->completedEvents.fetch_add(1, std::memory_order_relaxed) + 1;
 
-
+  CompletedEvents++;
+  
   if(completed%everyNevents == 0 && event_id > 0) {
 
     G4AutoLock lock(&outputMutex);

--- a/src/RunAction.cc
+++ b/src/RunAction.cc
@@ -3,6 +3,10 @@
 #include "G4Timer.hh"
 extern G4Timer Timer;
 
+#ifdef G4MULTITHREADED
+#include "G4MTRunManager.hh"
+#endif
+
 RunAction::RunAction(DetectorConstruction* detector, Incoming_Beam* BI,EventAction* ev): myDetector(detector), BeamIn(BI), evaction(ev)
 {
 
@@ -30,10 +34,13 @@ void RunAction::BeginOfRunAction(const G4Run* run)
   if(evaction->Mode2Out())
     G4cout << " Writing Mode 2 output to " 
 	   << evaction->GetMode2FileName() << G4endl;
+  Timer.Start();
+
+  }
   if(evaction->CacheOut()){
 #ifdef CACHETEXT
     std::ofstream& cacheOutputFile = evaction->getCacheOutputFile(); 
-    G4int Nevents = run->GetNumberOfEventToBeProcessed();
+    G4int Nevents = run->GetNumberOfEventToBeProcessed(); 
     cacheOutputFile << Nevents << G4endl;
 #else
     std::FILE* cacheOutputFile = evaction->getCacheOutputFile(); 
@@ -60,16 +67,24 @@ void RunAction::BeginOfRunAction(const G4Run* run)
     }
 #endif
     G4cout << Nevents << " events in cache file." << G4endl;
-    if (Nevents < run->GetNumberOfEventToBeProcessed()){
+
+    G4int nThreads = 1;
+
+#ifdef G4MULTITHREADED
+    G4MTRunManager* runManager = G4MTRunManager::GetMasterRunManager();
+    nThreads = runManager->GetNumberOfThreads();
+#endif
+
+    G4int eventsProcessed = float(run->GetNumberOfEventToBeProcessed())/float(nThreads);
+    
+    if (Nevents < eventsProcessed){
       G4cerr << "Error: There are only " << Nevents
 	     << " events in the cache file and the user has requested "
 	     << run->GetNumberOfEventToBeProcessed() << G4endl;
       exit(EXIT_FAILURE);
     }
   }
-  Timer.Start();
 
-  }
 
   evaction->SetNTotalevents(run->GetNumberOfEventToBeProcessed());
   if(run->GetNumberOfEventToBeProcessed() > 1000000)
@@ -89,14 +104,33 @@ void RunAction::BeginOfRunAction(const G4Run* run)
 
 
  
-void RunAction::EndOfRunAction(const G4Run*)
+void RunAction::EndOfRunAction(const G4Run* run)
 {
+
+  if(evaction->CacheOut()){
+    evaction->closeCacheOutputFile(); //close it so we can reopen and rewrite header
+#ifdef CACHETEXT
+    std::fstream cacheOutputFile(evaction->GetCacheOutputFilename(), std::ion::in | std::ion::out);
+    cacheOutputFile.seekp(0, std::ios::beg); 
+    G4int Nevents = evaction->GetCompletedEvents();
+    cacheOutputFile << Nevents << G4endl;
+    cacheOutputFile.close();
+#else
+    std::FILE* cacheOutputFile = std::fopen(evaction->GetCacheOutputFilename(), "r+");
+    std::fseek(cacheOutputFile, 0, SEEK_SET);
+    G4int Nevents = evaction->GetCompletedEvents();
+    fwrite(&Nevents, sizeof(G4int), 1, cacheOutputFile);
+    std::fclose(cacheOutputFile);
+#endif
+  }
+
+  
   if(evaction->EvOut())
     evaction->closeEvfile();
   if(evaction->Mode2Out())
     evaction->closeMode2file();
-  if(evaction->CacheOut())
-    evaction->closeCacheOutputFile();
+  //if(evaction->CacheOut())
+  //  evaction->closeCacheOutputFile();
   if(evaction->CacheIn())
     evaction->closeCacheInputFile();
 
@@ -174,8 +208,9 @@ void RunAction::EndOfRunAction(const G4Run*)
     G4cout << std::setprecision(2) << std::setw(5) << seconds;
   G4cout << std::setfill(' ');
 
+  
   G4cout << "   "
-	 << evaction->GetNTotalevents()/Timer.GetRealElapsed()
+	 << run->GetNumberOfEventToBeProcessed()/Timer.GetRealElapsed()
 	 << " events/s" << G4endl;
 
   }


### PR DESCRIPTION
I realized the time remaining was incorrect due to inconsistent timings and Geant4 does not respect event order in MT. I've included a small stopwatch helper that keeps track of the completed events using thread-safe atomic<int> and uses a global timer that each thread can access. 